### PR TITLE
Link GitHub action user guides to index page

### DIFF
--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -2,3 +2,5 @@
 
 - [Testing a role within a collection](testing.md)
 - [Ensure content best practices](content-best-practices.md)
+- [Content CI GitHub action setup](ci-setup.md)
+- [Content Release GitHub action setup](content-release.md)


### PR DESCRIPTION
Add GitHub action content CI setup and release doc, to index page