### PR TITLE
Auto update adt version output inside README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,15 @@ The curated list of tools installed as part of the Ansible automation developer 
 
 In addition to installing each of the above tools, `ansible-dev-tools` provides an easy way to show the versions of the content creation tools that make up the current development environment.
 
+<!-- START -->
+
 ```
 $ adt --version
 ansible-builder                          3.0.0
 ansible-core                             2.16.2
 ansible-creator                          24.1.0
 ansible-dev-environment                  24.1.0
-ansible-dev-tools                        0.2.0a1.dev26
+ansible-dev-tools                        0.2.0a0
 ansible-lint                             6.22.2
 ansible-navigator                        3.6.0
 ansible-sign                             0.1.1
@@ -46,6 +48,8 @@ molecule                                 6.0.3
 pytest-ansible                           24.1.2
 tox-ansible                              2.1.0
 ```
+
+<!-- END -->
 
 ## Documentation
 

--- a/src/ansible_dev_tools/version_builder.py
+++ b/src/ansible_dev_tools/version_builder.py
@@ -5,10 +5,10 @@ import importlib.metadata
 
 PKGS = [
     "ansible-builder",
-    "ansible-dev-environment",
-    "ansible-dev-tools",
     "ansible-core",
     "ansible-creator",
+    "ansible-dev-environment",
+    "ansible-dev-tools",
     "ansible-lint",
     "ansible-navigator",
     "ansible-sign",

--- a/tools/update-readme.py
+++ b/tools/update-readme.py
@@ -1,0 +1,31 @@
+#!python3
+"""Script that tests rule markdown documentation."""
+from __future__ import annotations
+
+import re
+import subprocess
+
+from pathlib import Path
+
+
+if __name__ == "__main__":
+    result = subprocess.run(
+        "adt --version",  # noqa: S607
+        shell=True,  # noqa: S602
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    file = Path("README.md")
+    with file.open(encoding="utf-8", mode="r+") as fh:
+        content = fh.read()
+        content = re.sub(
+            "<!-- START -->(.*?)<!-- END -->",
+            f"<!-- START -->\n\n```\n$ adt --version\n{result.stdout}```\n\n<!-- END -->",
+            content,
+            flags=re.DOTALL,
+        )
+        fh.seek(0)
+        fh.write(content)
+        fh.truncate()

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,9 @@ set_env =
 commands =
     coverage run --debug=trace -m pytest {posargs}
     sh -c "coverage combine -q .tox/.coverage.* && coverage xml || true && coverage report"
+    git diff --exit-code
 allowlist_externals =
+    bash
     git
     rm
     sh
@@ -65,18 +67,19 @@ commands =
       --outdir {toxinidir}/dist/ \
       {toxinidir}
     sh -c "python -m twine check --strict {toxinidir}/dist/*"
-    pip install --target=.tox/dist '.[test,docs]'
+    pip install '.[test,docs]'
+    adt --version
 
 [testenv:docs]
 description = Builds docs
-package = editable
-skip_install = false
-extras =
-    docs
+skip_install = true
 set_env =
     NO_COLOR = 1
     TERM = dump
 commands =
+    bash -c "SETUPTOOLS_SCM_PRETEND_VERSION=$(git describe --tags --abbrev=0) pip install -q -e '.[docs]'"
+    adt --version
+    python3 tools/update-readme.py
     mkdocs {posargs:build --strict --site-dir=_readthedocs/html/}
 
 [testenv:deps]


### PR DESCRIPTION
- keep the readme versions in sync with tested ones
- add ansible-dev-environment to the list of components

Fixes: #107