### PR TITLE
Upgrade dependencies

### DIFF
--- a/.config/constraints.txt
+++ b/.config/constraints.txt
@@ -7,9 +7,9 @@
 ansible-builder==3.0.0
 ansible-compat==4.1.11
 ansible-core==2.16.3
-ansible-creator==24.1.0
+ansible-creator==24.2.0
 ansible-dev-environment==24.1.0
-ansible-lint==6.22.2
+ansible-lint==24.2.0
 ansible-navigator==24.2.0
 ansible-runner==2.3.4
 ansible-sign==0.1.1
@@ -51,7 +51,7 @@ htmlmin2==0.1.13
 identify==2.5.33
 idna==3.6
 iniconfig==2.0.0
-jinja2==3.1.2
+jinja2==3.1.3
 jsmin==3.0.1
 jsonschema==4.21.1
 jsonschema-specifications==2023.12.1

--- a/.config/constraints.txt
+++ b/.config/constraints.txt
@@ -127,7 +127,7 @@ toml-sort==0.23.1
 tomli==2.0.1
 tomlkit==0.12.3
 tox==4.12.1
-tox-ansible==2.1.0
+tox-ansible==24.2.0
 types-setuptools==69.0.0.20240125
 typing-extensions==4.9.0
 tzdata==2023.4

--- a/.config/requirements-lock.txt
+++ b/.config/requirements-lock.txt
@@ -7,9 +7,9 @@
 ansible-builder==3.0.0
 ansible-compat==4.1.11
 ansible-core==2.16.3
-ansible-creator==24.1.0
+ansible-creator==24.2.0
 ansible-dev-environment==24.1.0
-ansible-lint==6.22.2
+ansible-lint==24.2.0
 ansible-navigator==24.2.0
 ansible-runner==2.3.4
 ansible-sign==0.1.1
@@ -32,7 +32,7 @@ exceptiongroup==1.2.0
 execnet==2.0.2
 filelock==3.13.1
 iniconfig==2.0.0
-jinja2==3.1.2
+jinja2==3.1.3
 jsonschema==4.21.1
 jsonschema-specifications==2023.12.1
 lockfile==0.12.2

--- a/.config/requirements-lock.txt
+++ b/.config/requirements-lock.txt
@@ -70,7 +70,7 @@ six==1.16.0
 subprocess-tee==0.4.1
 tomli==2.0.1
 tox==4.12.1
-tox-ansible==2.1.0
+tox-ansible==24.2.0
 types-setuptools==69.0.0.20240125
 typing-extensions==4.9.0
 tzdata==2023.4

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ In addition to installing each of the above tools, `ansible-dev-tools` provides 
 $ adt --version
 ansible-builder                          3.0.0
 ansible-core                             2.16.3
-ansible-creator                          24.1.0
+ansible-creator                          24.2.0
 ansible-dev-environment                  24.1.0
 ansible-dev-tools                        0.2.0a0
-ansible-lint                             6.22.2
+ansible-lint                             24.2.0
 ansible-navigator                        24.2.0
 ansible-sign                             0.1.1
 molecule                                 6.0.3

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ ansible-navigator                        24.2.0
 ansible-sign                             0.1.1
 molecule                                 6.0.3
 pytest-ansible                           24.1.2
-tox-ansible                              2.1.0
+tox-ansible                              24.2.0
 ```
 
 <!-- END -->

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -47,14 +47,14 @@ In addition to installing each of the above tools, `ansible-dev-tools` provides 
 ```
 $ adt --version
 ansible-builder                          3.0.0
-ansible-core                             2.16.2
-ansible-creator                          24.1.0
+ansible-core                             2.16.3
+ansible-creator                          24.2.0
 ansible-dev-environment                  24.1.0
-ansible-dev-tools                        0.2.0a1.dev26
-ansible-lint                             6.22.2
-ansible-navigator                        3.6.0
+ansible-dev-tools                        0.2.0a0
+ansible-lint                             24.2.0
+ansible-navigator                        24.2.0
 ansible-sign                             0.1.1
 molecule                                 6.0.3
 pytest-ansible                           24.1.2
-tox-ansible                              2.1.0
+tox-ansible                              24.2.0
 ```


### PR DESCRIPTION
This unblocks the jinja2 upgrade from https://github.com/ansible/ansible-dev-tools/pull/122