### PR TITLE
[adt server] make `--debug` work with `gunicorn`

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -1,3 +1,4 @@
+accesslog
 ADT
 Ansibuddy
 antsibull

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -104,6 +104,7 @@ repos:
           - django-stubs[compatible-mypy]
           - jinja2
           - pytest
+          - ansible-creator
           - tox
           - types-pyyaml
           - types-requests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ strict = true
 
 [[tool.mypy.overrides]]
 ignore_missing_imports = true
-module = ["gunicorn.*", "openapi_core.*", "ansible_creator.*"]
+module = ["gunicorn.*", "openapi_core.*"]
 
 [tool.pydoclint]
 allow-init-docstring = true

--- a/src/ansible_dev_tools/resources/server/creator.py
+++ b/src/ansible_dev_tools/resources/server/creator.py
@@ -96,8 +96,7 @@ class CreatorFrontendV1:
         )
 
 
-# TO-DO: remove type ignore after creator is released with py.typed
-class CreatorOutput(Output):  # type: ignore[misc]
+class CreatorOutput(Output):
     """The creator output."""
 
     def __init__(self: CreatorOutput, log_file: str) -> None:

--- a/src/ansible_dev_tools/subcommands/server.py
+++ b/src/ansible_dev_tools/subcommands/server.py
@@ -71,7 +71,6 @@ class Server:
         self.debug: bool = debug
 
         settings.configure(
-            DEBUG=self.debug,
             SECRET_KEY=os.environ.get("SECRET_KEY", os.urandom(32)),
             ALLOWED_HOSTS=[
                 "*",
@@ -91,4 +90,8 @@ class Server:
         options = {
             "bind": f"0.0.0.0:{self.port}",
         }
+        if self.debug:
+            # set log level to debug and write access logs to stdout
+            options.update({"loglevel": "debug", "accesslog": "-"})
+
         AdtServerApp(self.application, options).run()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -14,7 +14,9 @@ import pytest
 def dev_tools_server() -> Generator[str, None, None]:
     """Run the server."""
     bin_path = Path(sys.executable).parent / "adt"
-    with subprocess.Popen([bin_path, "server", "-p", "8000"]) as proc:  # noqa: S603
+    with subprocess.Popen(
+        [bin_path, "server", "-p", "8000", "--debug"],  # noqa: S603
+    ) as proc:
         time.sleep(1)  # allow the server to start
         yield "http://localhost:8000"
         proc.terminate()


### PR DESCRIPTION
```bash
(creator-server-py310) ➜  adt server --debug        
[2024-04-26 14:54:27 +0530] [1625770] [DEBUG] Current configuration:
  config: ./gunicorn.conf.py
  wsgi_app: None
  bind: ['0.0.0.0:8000']
  backlog: 2048
  workers: 1
  worker_class: sync
  threads: 1
  worker_connections: 1000
  max_requests: 0
  max_requests_jitter: 0
  timeout: 30
  graceful_timeout: 30
  keepalive: 2
  limit_request_line: 4094
  limit_request_fields: 100
  limit_request_field_size: 8190
  reload: False
  reload_engine: auto
  reload_extra_files: []
  spew: False
  check_config: False
  print_config: False
  preload_app: False
  sendfile: None
  reuse_port: False
  chdir: /home/nchakrab/ansible-dev-tools
  daemon: False
  raw_env: []
  pidfile: None
  worker_tmp_dir: None
  user: 1000
  group: 1000
  umask: 0
  initgroups: False
  tmp_upload_dir: None
  secure_scheme_headers: {'X-FORWARDED-PROTOCOL': 'ssl', 'X-FORWARDED-PROTO': 'https', 'X-FORWARDED-SSL': 'on'}
  forwarded_allow_ips: ['127.0.0.1']
  accesslog: -
  disable_redirect_access_to_syslog: False
  access_log_format: %(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"
  errorlog: -
  loglevel: debug
  capture_output: False
  logger_class: gunicorn.glogging.Logger
  logconfig: None
  logconfig_dict: {}
  logconfig_json: None
  syslog_addr: udp://localhost:514
  syslog: False
  syslog_prefix: None
  syslog_facility: user
  enable_stdio_inheritance: False
  statsd_host: None
  dogstatsd_tags: 
  statsd_prefix: 
  proc_name: None
  default_proc_name: gunicorn
  pythonpath: None
  paste: None
  on_starting: <function OnStarting.on_starting at 0x7fef7f169fc0>
  on_reload: <function OnReload.on_reload at 0x7fef7f16a0e0>
  when_ready: <function WhenReady.when_ready at 0x7fef7f16a200>
  pre_fork: <function Prefork.pre_fork at 0x7fef7f16a320>
  post_fork: <function Postfork.post_fork at 0x7fef7f16a440>
  post_worker_init: <function PostWorkerInit.post_worker_init at 0x7fef7f16a560>
  worker_int: <function WorkerInt.worker_int at 0x7fef7f16a680>
  worker_abort: <function WorkerAbort.worker_abort at 0x7fef7f16a7a0>
  pre_exec: <function PreExec.pre_exec at 0x7fef7f16a8c0>
  pre_request: <function PreRequest.pre_request at 0x7fef7f16a9e0>
  post_request: <function PostRequest.post_request at 0x7fef7f16aa70>
  child_exit: <function ChildExit.child_exit at 0x7fef7f16ab90>
  worker_exit: <function WorkerExit.worker_exit at 0x7fef7f16acb0>
  nworkers_changed: <function NumWorkersChanged.nworkers_changed at 0x7fef7f16add0>
  on_exit: <function OnExit.on_exit at 0x7fef7f16aef0>
  ssl_context: <function NewSSLContext.ssl_context at 0x7fef7f16b010>
  proxy_protocol: False
  proxy_allow_ips: ['127.0.0.1']
  keyfile: None
  certfile: None
  ssl_version: 2
  cert_reqs: 0
  ca_certs: None
  suppress_ragged_eofs: True
  do_handshake_on_connect: False
  ciphers: None
  raw_paste_global_conf: []
  strip_header_spaces: False
  permit_unconventional_http_method: False
  permit_unconventional_http_version: False
  casefold_http_method: False
  header_map: drop
  tolerate_dangerous_framing: False
[2024-04-26 14:54:27 +0530] [1625770] [INFO] Starting gunicorn 22.0.0
[2024-04-26 14:54:27 +0530] [1625770] [DEBUG] Arbiter booted
[2024-04-26 14:54:27 +0530] [1625770] [INFO] Listening at: http://0.0.0.0:8000 (1625770)
[2024-04-26 14:54:27 +0530] [1625770] [INFO] Using worker: sync
[2024-04-26 14:54:27 +0530] [1625771] [INFO] Booting worker with pid: 1625771
[2024-04-26 14:54:27 +0530] [1625770] [DEBUG] 1 workers
[2024-04-26 14:54:31 +0530] [1625771] [DEBUG] worker: SIGWINCH ignored.
[2024-04-26 14:54:31 +0530] [1625770] [INFO] Handling signal: winch
[2024-04-26 14:54:31 +0530] [1625770] [DEBUG] SIGWINCH ignored. Not daemonized
[2024-04-26 14:54:39 +0530] [1625771] [DEBUG] POST /v1/creator/collection
    Note: collection namespace.name created at
          /tmp/tmpuzjuacm1/namespace.name
127.0.0.1 - - [26/Apr/2024:14:54:39 +0530] "POST /v1/creator/collection HTTP/1.1" 201 24789 "-" "curl/8.2.1"
```