### PR TITLE
Add missing dep for mypy

### DIFF
--- a/.config/constraints.txt
+++ b/.config/constraints.txt
@@ -40,8 +40,8 @@ defusedxml==0.7.1
 distlib==0.3.8
 distro==1.9.0
 django==4.2.11
-django-stubs==4.2.7
-django-stubs-ext==4.2.7
+django-stubs==5.0.0
+django-stubs-ext==5.0.0
 dnspython==2.6.1
 docstring-parser-fork==0.0.5
 docutils==0.21.1
@@ -85,7 +85,7 @@ mkdocstrings==0.24.3
 mkdocstrings-python==1.10.0
 molecule==24.2.1
 more-itertools==10.2.0
-mypy==1.7.1
+mypy==1.10.0
 mypy-extensions==1.0.0
 nodeenv==1.8.0
 onigurumacffi==1.3.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -114,8 +114,9 @@ repos:
         args:
           - src
           - tests
+          - --python-version=3.12
+
         pass_filenames: false
-        language_version: "3.12"
 
   - repo: https://github.com/jazzband/pip-tools
     rev: 7.4.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -111,12 +111,6 @@ repos:
           - types-pyyaml
           - types-requests
           - types-setuptools
-        args:
-          - src
-          - tests
-          - --python-version=3.12
-
-        pass_filenames: false
 
   - repo: https://github.com/jazzband/pip-tools
     rev: 7.4.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -102,10 +102,11 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies:
+          - ansible-creator
           - django-stubs[compatible-mypy]
           - jinja2
+          - openapi-core>=0.19.1
           - pytest
-          - ansible-creator
           - tox
           - types-pyyaml
           - types-requests
@@ -114,7 +115,7 @@ repos:
           - src
           - tests
         pass_filenames: false
-        language_version: "3.10"
+        language_version: "3.12"
 
   - repo: https://github.com/jazzband/pip-tools
     rev: 7.4.1
@@ -122,11 +123,7 @@ repos:
       - id: pip-compile
         name: deps
         alias: deps
-        always_run: true
         stages: [manual]
-        entry: >
-          sh -c "
-          pip-compile --upgrade --no-annotate --strip-extras --output-file=.config/requirements-lock.txt pyproject.toml &&
-          pip-compile --upgrade --no-annotate --all-extras --strip-extras --output-file=.config/constraints.txt pyproject.toml"
+        entry: pip-compile .config/requirements.in --upgrade --all-extras --no-annotate --strip-extras --output-file=.config/constraints.txt pyproject.toml
         files: ^.config\/.*requirements.*$
         language_version: "3.10" # minimal we support officially

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -106,9 +106,11 @@ repos:
           - django-stubs[compatible-mypy]
           - jinja2
           - openapi-core>=0.19.1
+          - pytest
           - types-PyYAML
           - types-requests
           - types-setuptools
+        # Override default pre-commit '--ignore-missing-imports'
         args: [--strict]
 
   - repo: https://github.com/jazzband/pip-tools

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -106,11 +106,10 @@ repos:
           - django-stubs[compatible-mypy]
           - jinja2
           - openapi-core>=0.19.1
-          - pytest
-          - tox
-          - types-pyyaml
+          - types-PyYAML
           - types-requests
           - types-setuptools
+        args: [--strict]
 
   - repo: https://github.com/jazzband/pip-tools
     rev: 7.4.1

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,9 +2,9 @@
   "recommendations": [
     "charliermarsh.ruff",
     "esbenp.prettier-vscode",
-    "matangover.mypy",
     "ms-python.black-formatter",
     "ms-python.flake8",
+    "ms-python.mypy-type-checker",
     "ms-python.pylint"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,17 +1,18 @@
 {
-  "python.testing.unittestEnabled": false,
-  "python.testing.pytestEnabled": true,
-  // Override the pyproject.toml and disable xdist to enable test debugging
-  "python.testing.pytestArgs": ["-n0", "--dist", "no"],
-  "[python]": {
-    "editor.formatOnSave": true,
-    "editor.codeActionsOnSave": {
-      "source.fixAll": "explicit"
-    }
-  },
-  "mypy.runUsingActiveInterpreter": true,
-  "mypy.targets": ["src", "tests"],
   "[jsonc]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
-  }
+  },
+  "[python]": {
+    "editor.codeActionsOnSave": {
+      "source.fixAll": "explicit"
+    },
+    "editor.formatOnSave": true
+  },
+  "mypy-type-checker.args": ["--config-file=${workspaceFolder}/pyproject.toml"],
+  "mypy-type-checker.importStrategy": "fromEnvironment",
+  "mypy-type-checker.preferDaemon": true,
+  "mypy-type-checker.reportingScope": "workspace",
+  "python.testing.pytestArgs": ["tests"],
+  "python.testing.pytestEnabled": true,
+  "python.testing.unittestEnabled": false
 }

--- a/src/ansible_dev_tools/resources/server/creator.py
+++ b/src/ansible_dev_tools/resources/server/creator.py
@@ -56,7 +56,7 @@ class CreatorFrontendV1:
         with tempfile.TemporaryDirectory() as tmp_dir:
             # result.body here is a dict, it appear the type hint is wrong
             tar_file = CreatorBackend(Path(tmp_dir)).playbook(
-                **result.body,
+                **result.body,  # type: ignore[arg-type]
             )
             response = self._response_from_tar(tar_file)
 
@@ -83,7 +83,7 @@ class CreatorFrontendV1:
         with tempfile.TemporaryDirectory() as tmp_dir:
             # result.body here is a dict, it appear the type hint is wrong
             tar_file = CreatorBackend(Path(tmp_dir)).collection(
-                **result.body,
+                **result.body,  # type: ignore[arg-type]
             )
             response = self._response_from_tar(tar_file)
 

--- a/src/ansible_dev_tools/server_utils.py
+++ b/src/ansible_dev_tools/server_utils.py
@@ -54,7 +54,7 @@ def validate_response(
     try:
         OPENAPI.validate_response(
             request=DjangoOpenAPIRequest(request),
-            response=DjangoOpenAPIResponse(response),
+            response=DjangoOpenAPIResponse(response),  # type: ignore[arg-type]
         )
     except OpenAPIError as exc:
         return HttpResponse(str(exc), status=400)


### PR DESCRIPTION
It was found running mypy locally had different result than with pre-commit, This was due to a missing openapi-core dep in the precommit config.

- Add missing dep for precommit/mypy
- Update VsCode extension to the MS one, add config
- Manually update the constraints to mathc the mypy precommit version
- Remediate newly found errors 