### PR TITLE
chore: Update .github/workflows/tox.yml

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches:
       - "main"
+  workflow_call:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}


### PR DESCRIPTION
The tox workflow is called by release and therefore needs `workflow_call`
