### PR TITLE
Docsite, README: Add communication information

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ The curated list of tools installed as part of the Ansible automation developer 
 
 [ansible-dev-environment](https://github.com/ansible/ansible-dev-environment): A pip-like install for Ansible collections.
 
+## Communication
+
+Refer to our [Communication guide](https://ansible.readthedocs.io/projects/dev-tools/contributor-guide/#talk-to-us) for details.
+
 ## Installation
 
 `python3 -m pip install ansible-dev-tools`

--- a/docs/contributor-guide.md
+++ b/docs/contributor-guide.md
@@ -62,23 +62,28 @@ See the `tests/integration/test_container.py` for examples.
 
 ## Talk to us
 
-Use Github [discussions] forum or for a live chat experience try
-`#ansible-devtools` IRC channel on libera.chat or Matrix room
-[#devtools:ansible.com](https://matrix.to/#/#devtools:ansible.com).
+* Join the Ansible forum:
+    * [Get Help](https://forum.ansible.com/c/help/6): get help or help others. Please add appropriate tags if you start new discussions, for example the `devtools` tag.
+    * [Posts tagged with 'devtools'](https://forum.ansible.com/tag/devtools): subscribe to participate in project-related conversations.
+    * [Social Spaces](https://forum.ansible.com/c/chat/4): gather and interact with fellow enthusiasts.
+    * [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide announcements including social events.
 
-For the full list of Ansible IRC and Mailing list, please see the [Ansible
-Communication] page. Release announcements will be made to the [Ansible
-Announce] list.
+* The Ansible [Bullhorn newsletter]: used to announce releases and important changes.
+
+* We are also available on the following chat platforms:
+    * Matrix: in the [#devtools:ansible.com](https://matrix.to/#/#devtools:ansible.com) room.
+    * Libera.Chat: in the `#ansible-devtools` Libera.Chat IRC channel.
 
 Possible security bugs should be reported via email to
 <mailto:security@ansible.com>.
+
+For more information about communication, see the [Ansible communication guide].
 
 ## Code of Conduct
 
 Please see the official [Ansible Community Code of Conduct].
 
-[discussions]: https://github.com/ansible/ansible-dev-tools/discussions
-[ansible communication]: https://docs.ansible.com/ansible/latest/community/communication.html
-[ansible announce]: https://groups.google.com/forum/#!forum/ansible-announce
+[Ansible communication guide]: https://docs.ansible.com/ansible/devel/community/communication.html
 [Ansible Community Code of Conduct]: https://docs.ansible.com/ansible/latest/community/code_of_conduct.html
 [creating your fork on github]: https://docs.github.com/en/get-started/quickstart/contributing-to-projects
+[Bullhorn newsletter]: https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn

--- a/docs/contributor-guide.md
+++ b/docs/contributor-guide.md
@@ -70,7 +70,6 @@ See the `tests/integration/test_container.py` for examples.
   - [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide announcements including social events.
   - [Bullhorn newsletter](https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn): used to announce releases and important changes.
 
-- The Ansible [Bullhorn newsletter]: used to announce releases and important changes.
 
 - We are also available on the following chat platforms:
   - Matrix: in the [#devtools:ansible.com](https://matrix.to/#/#devtools:ansible.com) room.

--- a/docs/contributor-guide.md
+++ b/docs/contributor-guide.md
@@ -62,17 +62,18 @@ See the `tests/integration/test_container.py` for examples.
 
 ## Talk to us
 
-* Join the Ansible forum:
-    * [Get Help](https://forum.ansible.com/c/help/6): get help or help others. Please add appropriate tags if you start new discussions, for example the `devtools` tag.
-    * [Posts tagged with 'devtools'](https://forum.ansible.com/tag/devtools): subscribe to participate in project-related conversations.
-    * [Social Spaces](https://forum.ansible.com/c/chat/4): gather and interact with fellow enthusiasts.
-    * [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide announcements including social events.
+- Join the Ansible forum:
 
-* The Ansible [Bullhorn newsletter]: used to announce releases and important changes.
+  - [Get Help](https://forum.ansible.com/c/help/6): get help or help others. Please add appropriate tags if you start new discussions, for example the `devtools` tag.
+  - [Posts tagged with 'devtools'](https://forum.ansible.com/tag/devtools): subscribe to participate in project-related conversations.
+  - [Social Spaces](https://forum.ansible.com/c/chat/4): gather and interact with fellow enthusiasts.
+  - [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide announcements including social events.
 
-* We are also available on the following chat platforms:
-    * Matrix: in the [#devtools:ansible.com](https://matrix.to/#/#devtools:ansible.com) room.
-    * Libera.Chat: in the `#ansible-devtools` Libera.Chat IRC channel.
+- The Ansible [Bullhorn newsletter]: used to announce releases and important changes.
+
+- We are also available on the following chat platforms:
+  - Matrix: in the [#devtools:ansible.com](https://matrix.to/#/#devtools:ansible.com) room.
+  - Libera.Chat: in the `#ansible-devtools` Libera.Chat IRC channel.
 
 Possible security bugs should be reported via email to
 <mailto:security@ansible.com>.

--- a/docs/contributor-guide.md
+++ b/docs/contributor-guide.md
@@ -70,7 +70,6 @@ See the `tests/integration/test_container.py` for examples.
   - [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide announcements including social events.
   - [Bullhorn newsletter](https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn): used to announce releases and important changes.
 
-
 - We are also available on the following chat platforms:
   - Matrix: in the [#devtools:ansible.com](https://matrix.to/#/#devtools:ansible.com) room.
   - Libera.Chat: in the `#ansible-devtools` Libera.Chat IRC channel.

--- a/docs/contributor-guide.md
+++ b/docs/contributor-guide.md
@@ -63,6 +63,7 @@ See the `tests/integration/test_container.py` for examples.
 ## Talk to us
 
 - Join the Ansible forum:
+
   - [Get Help](https://forum.ansible.com/c/help/6): get help or help others. Please add appropriate tags if you start new discussions, for example the `devtools` tag.
   - [Posts tagged with 'devtools'](https://forum.ansible.com/tag/devtools): subscribe to participate in project-related conversations.
   - [Social Spaces](https://forum.ansible.com/c/chat/4): gather and interact with fellow enthusiasts.

--- a/docs/contributor-guide.md
+++ b/docs/contributor-guide.md
@@ -63,11 +63,11 @@ See the `tests/integration/test_container.py` for examples.
 ## Talk to us
 
 - Join the Ansible forum:
-
   - [Get Help](https://forum.ansible.com/c/help/6): get help or help others. Please add appropriate tags if you start new discussions, for example the `devtools` tag.
   - [Posts tagged with 'devtools'](https://forum.ansible.com/tag/devtools): subscribe to participate in project-related conversations.
   - [Social Spaces](https://forum.ansible.com/c/chat/4): gather and interact with fellow enthusiasts.
   - [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide announcements including social events.
+  - [Bullhorn newsletter](https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn): used to announce releases and important changes.
 
 - The Ansible [Bullhorn newsletter]: used to announce releases and important changes.
 
@@ -78,13 +78,11 @@ See the `tests/integration/test_container.py` for examples.
 Possible security bugs should be reported via email to
 <mailto:security@ansible.com>.
 
-For more information about communication, see the [Ansible communication guide].
+For more information about communication, see the [Ansible communication guide](https://docs.ansible.com/ansible/devel/community/communication.html).
 
 ## Code of Conduct
 
 Please see the official [Ansible Community Code of Conduct].
 
-[Ansible communication guide]: https://docs.ansible.com/ansible/devel/community/communication.html
 [Ansible Community Code of Conduct]: https://docs.ansible.com/ansible/latest/community/code_of_conduct.html
 [creating your fork on github]: https://docs.github.com/en/get-started/quickstart/contributing-to-projects
-[Bullhorn newsletter]: https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,9 +51,9 @@ extra:
     - icon: simple/matrix
       link: https://matrix.to/#/#devtools:ansible.com
       name: Matrix
-    - icon: fontawesome/solid/comments
-      link: https://github.com/ansible/ansible-dev-tools/discussions
-      name: Discussions
+    - icon: fontawesome/brands/discourse
+      link: https://forum.ansible.com/c/project/7
+      name: Ansible forum
     - icon: fontawesome/brands/github-alt
       link: https://github.com/ansible/ansible-dev-tools
       name: GitHub


### PR DESCRIPTION
Dear maintainers,
As a part of the [Consolidating Ansible discussion platforms initiative](https://forum.ansible.com/t/proposal-consolidating-ansible-discussion-platforms/6812), this PR adds the communication section template defined by the community to the README and the docsite. Similar PRs are now being raised across all the Ansible ecosystem projects.

Thank you