### PR TITLE
Use pipx to install build dependencies on GHA runners

### DIFF
--- a/.github/actions/build-test/action.yml
+++ b/.github/actions/build-test/action.yml
@@ -85,14 +85,13 @@ runs:
     - name: Squash image layers to save disk space
       shell: bash
       run: |
-        python3 -m pipx install docker-squash
+        python3 -m pipx install --force docker-squash
         docker-squash ${{ inputs.namespace }}/${{ inputs.final_image }}:test
 
     - name: Run tests against the container
       shell: bash
       run: |
-        python3 -m pip install --upgrade pip
-        python3 -m pip install --upgrade "tox>=4.0.0"
+        python3 -m pipx install --force "tox>=4.0.0"
         tox -e test-image -- --container-engine docker --image-name ${{ inputs.namespace }}/${{ inputs.final_image }}:test
 
     - name: Push the built image to ${{ inputs.registry }} by digest for ${{ matrix.platform }}

--- a/.github/actions/build-test/action.yml
+++ b/.github/actions/build-test/action.yml
@@ -26,6 +26,7 @@ runs:
       run: |
         platform=${{ matrix.platform }}
         echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+        sudo apt install -y python3-pip python3-build pipx
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
@@ -37,7 +38,8 @@ runs:
       shell: bash
       id: ansible-builder-install
       run: |
-        python3 -m pip install -U ansible-builder build
+        set -ex
+        python3 -m pipx install --force ansible-builder
         python3 -m build --outdir final/dist/ --wheel
 
     - name: Create a build context and Containerfile for base EE
@@ -83,7 +85,7 @@ runs:
     - name: Squash image layers to save disk space
       shell: bash
       run: |
-        python3 -m pip install --upgrade docker-squash
+        python3 -m pipx install docker-squash
         docker-squash ${{ inputs.namespace }}/${{ inputs.final_image }}:test
 
     - name: Run tests against the container

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -36,8 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - builder: ubuntu-24.04
-            # devtools-multiarch-builder
+          - builder: devtools-multiarch-builder
             platform: linux/amd64
             name: amd64
           - builder: devtools-arm64-runner

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -36,7 +36,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - builder: devtools-multiarch-builder
+          - builder: ubuntu-24.04
+            # devtools-multiarch-builder
             platform: linux/amd64
             name: amd64
           - builder: devtools-arm64-runner


### PR DESCRIPTION
This should make the GHA runner setup work better with more OS versions.
Needed-By: #367