### PR TITLE
Removing --user=root param for container-in-container test

### DIFF
--- a/tests/integration/test_container.py
+++ b/tests/integration/test_container.py
@@ -57,7 +57,7 @@ def test_container_in_container(
         exec_container: The container executor.
     """
     podman_run_container = exec_container(
-        "podman run -i --rm -d -e ANSIBLE_DEV_TOOLS_CONTAINER=1 --user=root"
+        "podman run -i --rm -d -e ANSIBLE_DEV_TOOLS_CONTAINER=1"
         " -e ANSIBLE_FORCE_COLOR=0 --name ghcr_io_ansible_community_ansible_dev_tools_latest"
         " ghcr.io/ansible/community-ansible-dev-tools:latest bash",
     )


### PR DESCRIPTION
Fixing intentional workaround from #364. 

This was originally introduced to delay CI failure between the release of the updated image using root as the default user. The workaround is no longer needed now that ADT 24.9.0 is out. 