### PR TITLE
Switch reference python version to 3.11

### DIFF
--- a/.config/constraints.txt
+++ b/.config/constraints.txt
@@ -2,6 +2,7 @@
 #    tox run deps
 ansible-builder==3.1.0
 ansible-compat==24.10.0
+ansible-core==2.18.1
 ansible-creator==24.12.0
 ansible-dev-environment==24.12.0
 ansible-lint==24.12.2
@@ -42,7 +43,6 @@ django-stubs-ext==5.1.1
 dnspython==2.7.0
 docstring-parser-fork==0.0.9
 enrich==1.2.7
-exceptiongroup==1.2.2
 execnet==2.1.1
 filelock==3.16.1
 ghp-import==2.1.0
@@ -144,7 +144,6 @@ termcolor==2.5.0
 text-unidecode==1.3
 tinycss2==1.4.0
 toml-sort==0.24.2
-tomli==2.2.1
 tomlkit==0.13.2
 tox==4.23.2
 tox-ansible==24.12.0
@@ -162,7 +161,6 @@ yamllint==1.35.1
 zipp==3.21.0
 
 # The following packages were excluded from the output:
-# ansible-core
 # pip
 # resolvelib
 # typing-extensions

--- a/.config/requirements-lock.txt
+++ b/.config/requirements-lock.txt
@@ -2,6 +2,7 @@
 #    tox run deps
 ansible-builder==3.1.0
 ansible-compat==24.10.0
+ansible-core==2.18.1
 ansible-creator==24.12.0
 ansible-dev-environment==24.12.0
 ansible-lint==24.12.2
@@ -22,7 +23,6 @@ cryptography==44.0.0
 distlib==0.3.9
 distro==1.9.0
 enrich==1.2.7
-exceptiongroup==1.2.2
 execnet==2.1.1
 filelock==3.16.1
 importlib-metadata==8.5.0
@@ -60,7 +60,6 @@ rpds-py==0.22.3
 ruamel-yaml==0.18.6
 ruamel-yaml-clib==0.2.12
 subprocess-tee==0.4.2
-tomli==2.2.1
 tox==4.23.2
 tox-ansible==24.12.0
 tzdata==2024.2
@@ -70,7 +69,5 @@ yamllint==1.35.1
 zipp==3.21.0
 
 # The following packages were excluded from the output:
-# ansible-core
 # resolvelib
-# typing-extensions
 # setuptools

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -32,7 +32,7 @@ jobs:
     with:
       run_pre: ./tools/test-setup.sh
       max_python: "3.13"
-      default_python: "3.10" # min version, for 'lint' in particular
+      default_python: "3.11" # min version, for 'lint' in particular
       jobs_producing_coverage: 8
       other_names_also: |
         devspaces
@@ -127,10 +127,10 @@ jobs:
       TOXENV: pkg
       TOX_EXTRA_BINDEP: 0
     steps:
-      - name: Switch to using Python 3.10 by default
+      - name: Switch to using Python 3.11 by default
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install tox
         run: python3 -m pip install --user "tox>=4.0.0"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,10 @@ ci:
 default_language_version:
   # minimal version we support officially as this will impact mypy, pylint and
   # pip-tools in undesirable ways.
-  python: "3.10"
+  # minimal version determined by minimal version required by ansible-core, but
+  # we might keep a backwards compatibility version for older ones, but the
+  # lock extra will not be usable those.
+  python: "3.11"
 repos:
   # - repo: https://github.com/rhysd/actionlint
   #   rev: v1.7.3
@@ -93,7 +96,7 @@ repos:
         name: Spell check with cspell
 
   - repo: https://github.com/jsh9/pydoclint
-    rev: "0.5.9"
+    rev: "0.5.12"
     hooks:
       - id: pydoclint
         # This allows automatic reduction of the baseline file when needed.
@@ -142,7 +145,7 @@ repos:
         name: Upgrade constraints files and requirements
         # files: ^(pyproject\.toml|requirements\.txt)$
         language: python
-        language_version: "3.10" # minimal we support officially
+        language_version: "3.11" # minimal required by latest ansible-core
         entry: python3 -m uv pip compile -q --all-extras --output-file=.config/constraints.txt pyproject.toml --upgrade
         pass_filenames: false
         stages:
@@ -153,7 +156,7 @@ repos:
         name: Check constraints files and requirements
         # files: ^(pyproject\.toml|requirements\.txt)$
         language: python
-        language_version: "3.10" # minimal we support officially
+        language_version: "3.11" # minimal required by latest ansible-core
         entry: python3 -m uv pip compile -q --all-extras --output-file=.config/constraints.txt pyproject.toml
         pass_filenames: false
         additional_dependencies:
@@ -165,7 +168,7 @@ repos:
         entry: python3 -m uv pip compile -q --upgrade --constraint=.config/constraints.txt --output-file=.config/requirements-lock.txt pyproject.toml --strip-extras
         files: ^.config\/.*requirements.*$
         language: python
-        language_version: "3.10" # minimal we support officially
+        language_version: "3.11" # minimal required by latest ansible-core
         pass_filenames: false
         stages: [manual]
         additional_dependencies:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -370,6 +370,8 @@ convention = "google"
 [tool.setuptools.dynamic]
 dependencies = {file = [".config/requirements.in"]}
 optional-dependencies.docs = {file = [".config/requirements-docs.in"]}
+# 'lock' will work only if you use a python version supported by the latest
+# release of ansible-core, otherwise installation will fail
 optional-dependencies.lock = {file = [".config/requirements-lock.txt"]}
 optional-dependencies.server = {file = [".config/requirements-server.in"]}
 optional-dependencies.test = {file = [".config/requirements-test.in"]}
@@ -401,4 +403,4 @@ environments = ["platform_system != 'Windows'"]
 # annotation-style = "line"
 custom-compile-command = "tox run deps"
 no-annotate = true
-no-emit-package = ["ansible-core", "pip", "resolvelib", "typing_extensions", "uv", "pip", "distribute", "setuptools"]
+no-emit-package = ["pip", "resolvelib", "typing_extensions", "uv", "pip", "distribute", "setuptools"]

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,7 @@ allowlist_externals =
 
 [testenv:deps]
 description = Bump all dependencies
-base_python = python3.10
+base_python = python3.11
 skip_install = true
 deps =
     {[testenv:lint]deps}


### PR DESCRIPTION
While we still require python 3.10, the lock files are created only
for 3.11 in order to be able use newest ansible-core version.
