### PR TITLE
Update dependency testing

### DIFF
--- a/.config/constraints.txt
+++ b/.config/constraints.txt
@@ -142,7 +142,7 @@ text-unidecode==1.3
 tinycss2==1.4.0
 toml-sort==0.24.2
 tomlkit==0.13.2
-tox==4.23.2
+tox==4.24.1
 tox-ansible==25.1.0
 types-pyyaml==6.0.12.20241230
 types-requests==2.32.0.20241016

--- a/.config/requirements-lock.txt
+++ b/.config/requirements-lock.txt
@@ -60,7 +60,7 @@ rpds-py==0.22.3
 ruamel-yaml==0.18.6
 ruamel-yaml-clib==0.2.12
 subprocess-tee==0.4.2
-tox==4.23.2
+tox==4.24.1
 tox-ansible==25.1.0
 tzdata==2024.2
 virtualenv==20.28.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,8 +7,6 @@ ci:
   skip:
     - shellcheck # no docker support on pre-commit.ci
     - deps
-    - constraints
-    - lock
 default_language_version:
   # minimal version we support officially as this will impact mypy, pylint and
   # pip-tools in undesirable ways.
@@ -65,12 +63,12 @@ repos:
       - id: toml-sort-fix
 
   - repo: https://github.com/tox-dev/tox-ini-fmt
-    rev: 1.4.1
+    rev: 1.5.0
     hooks:
       - id: tox-ini-fmt
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.2
+    rev: v0.9.3
     hooks:
       - id: ruff
         args:
@@ -137,30 +135,14 @@ repos:
         # files: ^(pyproject\.toml|requirements\.txt)$
         language: python
         language_version: "3.11" # minimal required by latest ansible-core
-        entry: python3 -m uv pip compile -q --all-extras --output-file=.config/constraints.txt pyproject.toml --upgrade
+        # do not use --all-extra because it will include the lock extra which prevents upgrade
+        entry: >
+          bash -c
+          "python3 -m uv pip compile --upgrade -q --extra docs --extra server --extra test --output-file=.config/constraints.txt pyproject.toml;
+          python3 -m uv pip compile -q --upgrade --constraint=.config/constraints.txt --output-file=.config/requirements-lock.txt pyproject.toml --strip-extras
+          "
         pass_filenames: false
         stages:
           - manual
         additional_dependencies:
-          - uv>=0.4.3
-      - id: constraints
-        name: Check constraints files and requirements
-        # files: ^(pyproject\.toml|requirements\.txt)$
-        language: python
-        language_version: "3.11" # minimal required by latest ansible-core
-        entry: python3 -m uv pip compile -q --all-extras --output-file=.config/constraints.txt pyproject.toml
-        pass_filenames: false
-        additional_dependencies:
-          - uv>=0.4.3
-      - id: lock
-        name: Update requirements-lock.txt
-        alias: lock
-        always_run: true
-        entry: python3 -m uv pip compile -q --upgrade --constraint=.config/constraints.txt --output-file=.config/requirements-lock.txt pyproject.toml --strip-extras
-        files: ^.config\/.*requirements.*$
-        language: python
-        language_version: "3.11" # minimal required by latest ansible-core
-        pass_filenames: false
-        stages: [manual]
-        additional_dependencies:
-          - uv>=0.4.3
+          - uv>=0.5.4

--- a/tools/devspaces.sh
+++ b/tools/devspaces.sh
@@ -7,19 +7,17 @@ IMAGE_NAME=ansible/ansible-workspace-env-reference:test
 mkdir -p out dist
 # Ensure that we packaged the code first
 # shellcheck disable=SC2207
+rm -f dist/*.*
+tox -e pkg
+# shellcheck disable=SC2207
 WHEELS=($(find dist -name '*.whl' -maxdepth 1 -execdir echo '{}' ';'))
 if [ ${#WHEELS[@]} -ne 1 ]; then
-    tox -e pkg
-    # shellcheck disable=SC2207
-    WHEELS=($(find dist -name '*.whl' -maxdepth 1 -execdir echo '{}' ';'))
-    if [ ${#WHEELS[@]} -ne 1 ]; then
-        echo "Unable to find a single wheel file in dist/ directory: ${WHEELS[*]}"
-        exit 2
-    fi
+    echo "Unable to find a single wheel file in dist/ directory: ${WHEELS[*]}"
+    exit 2
 fi
 rm -f devspaces/context/*.whl
-cp dist/*.whl devspaces/context
-cp tools/setup-image.sh devspaces/context
+ln -f dist/*.whl devspaces/context
+ln -f tools/setup-image.sh devspaces/context
 
 # we force use of linux/amd64 platform because source image supports only this
 # platform and without it, it will fail to cross-build when task runs on arm64.

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 requires =
-    tox>=4.11.3
-    tox-extra>=2.0.2
-    tox-uv>=1.19
+    tox>=4.24.1
+    tox-extra>=2.1
+    tox-uv>=1.20.1
 env_list =
     py
     deps
@@ -79,9 +79,7 @@ extras =
 commands_pre =
 commands =
     -pre-commit run --all-files --show-diff-on-failure --hook-stage manual deps
-    -pre-commit run --all-files --show-diff-on-failure --hook-stage manual lock
     -pre-commit autoupdate
-    git diff --exit-code
 env_dir = {toxworkdir}/lint
 
 [testenv:docs]
@@ -100,8 +98,8 @@ commands =
 description = Enforce quality standards under {basepython}
 skip_install = true
 deps =
-    pre-commit
-    pre-commit-uv
+    pre-commit>=4.1
+    pre-commit-uv>=4.1.4
 commands =
     pre-commit run --show-diff-on-failure --all-files
 


### PR DESCRIPTION
Fixes a problem that prevented their update because 'lock' dependency was included when the "deps" hook did run, preventing their update.
