### PR TITLE
Ensure zsh and oh-my-zsh are installed on both images

### DIFF
--- a/final/setup.sh
+++ b/final/setup.sh
@@ -113,9 +113,6 @@ chsh -s "$(which zsh)" root
 python3 -m pip install argcomplete
 activate-global-python-argcomplete
 
-# Install oh-my-zsh
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
-
 # shellcheck disable=SC1091
 source "$DIR/setup-image.sh"
 

--- a/tools/ee.sh
+++ b/tools/ee.sh
@@ -63,7 +63,7 @@ fi
 python -m build --outdir "$REPO_DIR/final/dist/" --wheel "$REPO_DIR"
 ansible-builder create -f execution-environment.yml --output-filename Containerfile -v3
 $BUILD_CMD -f context/Containerfile context/ --tag "${TAG_BASE}"
-cp tools/setup-image.sh final/
+ln -f tools/setup-image.sh final/
 $BUILD_CMD -f final/Containerfile final/ --tag "${IMAGE_NAME}"
 
 # We save local image in order to import it inside the container later for c-in-c testing

--- a/tools/setup-image.sh
+++ b/tools/setup-image.sh
@@ -9,3 +9,11 @@ OC_VERSION=4.15
 curl -s -L "https://mirror.openshift.com/pub/openshift-v4/$(arch)/clients/ocp/stable-${OC_VERSION}/openshift-client-linux.tar.gz" | tar -C /usr/local/bin -xz --no-same-owner
 chmod +x /usr/local/bin/oc
 oc version --client=true
+
+# Ensure that we have a ~/.zshrc file as otherwise zsh will start its first run
+# wizard which will cause the container to hang. This was seen as happening on
+# ubi9 image but not on fedora one.
+touch ~/.zshrc
+
+# Install oh-my-zsh
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended


### PR DESCRIPTION
This brings the two container images closer and fixes two problems with zsh on devspaces container:

- login with zsh would block due to interactive first time install
- zsh prompt was broken

Further changes should also address the 10 currently ignored tests on devspaces image.