### PR TITLE
feat: add sbom to container images

### DIFF
--- a/tools/devspaces.sh
+++ b/tools/devspaces.sh
@@ -22,7 +22,7 @@ ln -f tools/setup-image.sh devspaces/context
 # we force use of linux/amd64 platform because source image supports only this
 # platform and without it, it will fail to cross-build when task runs on arm64.
 # --metadata-file=out/devspaces.meta --no-cache
-$ADT_CONTAINER_ENGINE buildx build --tag=$IMAGE_NAME --platform=linux/amd64 devspaces/context -f devspaces/Containerfile
+$ADT_CONTAINER_ENGINE buildx build --tag=$IMAGE_NAME --platform=linux/amd64 devspaces/context -f devspaces/Containerfile --sbom=true
 
 mk containers check $IMAGE_NAME --engine="${ADT_CONTAINER_ENGINE}" --max-size=1600 --max-layers=23
 

--- a/tools/ee.sh
+++ b/tools/ee.sh
@@ -25,7 +25,7 @@ TAG_BASE=community-ansible-dev-tools-base:latest
 IMAGE_NAME=localhost/community-ansible-dev-tools:test
 
 # BUILD_CMD="podman build --squash-all"
-BUILD_CMD="${ADT_CONTAINER_ENGINE} buildx build --progress=plain"
+BUILD_CMD="${ADT_CONTAINER_ENGINE} buildx build --progress=plain --sbom=true"
 
 # Publish should run on CI only on main branch, with or without release tag
 if [ "--publish" == "${1:-}" ]; then


### PR DESCRIPTION
Uses the `--sbom=true` flag to attach a `syft` SBOM to the manifest

Closes: #451