### PR TITLE
Fix devpsaces iptables version conflict

### DIFF
--- a/devspaces/context/setup.sh
+++ b/devspaces/context/setup.sh
@@ -4,7 +4,8 @@ set -eux pipefail
 
 DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-dnf --noplugins remove -y -q subscription-manager dnf-plugin-subscription-manager
+dnf --noplugins remove -y -q subscription-manager dnf-plugin-subscription-manager iptables-legacy
+dnf install -y -q iptables-nft
 dnf -y -q makecache
 dnf -y -q update
 dnf install -y -q \


### PR DESCRIPTION
This PR tries to fix the below encountered issue while building image
```
Problem: cannot install both iptables-libs-1.8.10-11.el9_5.x86_64 from ubi-9-baseos-rpms and iptables-libs-1.8.10-4.el9_4.x86_64 from @System
   - package iptables-legacy-1.8.10-4.1.el9.x86_64 from @System requires (iptables-libs(x86-64) = 1.8.10-4.el9 or iptables-libs(x86-64) = 1.8.10-4.el9_4), but none of the providers can be installed
   - cannot install the best update candidate for package iptables-libs-1.8.10-4.el9_4.x86_64
   - cannot install the best update candidate for package iptables-legacy-1.8.10-4.1.el9.x86_64
```
