### PR TITLE
Add RPM pinentry

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -26,6 +26,7 @@ mknod
 modifyitems
 netcommon
 opencontainers
+pinentry
 pkgmgr
 pylibssh
 seccomp

--- a/devspaces/context/setup.sh
+++ b/devspaces/context/setup.sh
@@ -27,6 +27,7 @@ dnf install -y -q \
     util-linux-user \
     which \
     zsh \
+    pinentry \
     --exclude container-selinux
 #     python${PYV}-ruamel-yaml \
 dnf -y -q clean all


### PR DESCRIPTION
Description of problem:

User is creating a GPG key to commit in his  repo. When he try to create a GPG key  the "error: error No pinentry" error is reported.

To solve this issue:

Adding RPM pinentry in file devspaces/context/setup.sh.

Context is presented here:  https://issues.redhat.com/browse/CRW-7895 

Thank you for your help!

---
Steps to Reproduce

1. Launch the workspace: Ansible 
then run ;
gpg --gen-key

2. After entering your name and e-mail you will have the error:
gpg: agent_genkey failed: No pinentry
Key generation failed: No pinentry
Actual results:

gpg creation results in following error:

gpg: key D79: error sending to agent: No pinentry

gpg: error building skey array: No pinentry

gpg: error reading 'myprivatekeys.asc': No pinentry

gpg: import from 'myprivatekeys.asc' failed: No pinentry
Expected results:

GPG key creation should proceed 