### PR TITLE
AAP-36964 - API endpoint to scaffold devfile using ansible-creator add subcommand

### DIFF
--- a/src/ansible_dev_tools/resources/server/creator_v2.py
+++ b/src/ansible_dev_tools/resources/server/creator_v2.py
@@ -222,7 +222,7 @@ class CreatorBackend:
         """Scaffold a devfile.
 
         Args:
-            project: The project type.
+            collection: The collection name.
 
         Returns:
             The tar file path.

--- a/src/ansible_dev_tools/resources/server/creator_v2.py
+++ b/src/ansible_dev_tools/resources/server/creator_v2.py
@@ -222,7 +222,7 @@ class CreatorBackend:
         Returns:
             The tar file path.
         """
-        # Path where the devfile will be added
+        # Path where the devfile is going to be added
         add_path = self.tmp_dir / "devfile"
         add_path.mkdir(parents=True, exist_ok=True)
 

--- a/src/ansible_dev_tools/resources/server/creator_v2.py
+++ b/src/ansible_dev_tools/resources/server/creator_v2.py
@@ -218,28 +218,26 @@ class CreatorBackend:
         create_tar_file(init_path, tar_file)
         return tar_file
 
-    def devfile(self, project: str, collection: str) -> Path:
+    def devfile(self, collection: str) -> Path:
         """Scaffold a devfile.
 
         Args:
             project: The project type.
-            devfile_name: The name of the devfile.
-            config_params: Configuration parameters for devfile creation.
 
         Returns:
             The tar file path.
         """
         # Path where the devfile will be added in the collection
-        add_path = self.tmp_dir / collection
+        add_path = self.tmp_dir / "devfile"
+        add_path.mkdir(parents=True, exist_ok=True)
 
         config = Config(
             resource_type="devfile",
-            project=project,
             creator_version=creator_version,
             path=str(add_path),
             output=CreatorOutput(log_file=str(self.tmp_dir / "creator.log")),
-            collection=collection,
             subcommand="add",
+            overwrite=True,
         )
         Add(config).run()
         tar_file = self.tmp_dir / "devfile.tar"

--- a/src/ansible_dev_tools/resources/server/creator_v2.py
+++ b/src/ansible_dev_tools/resources/server/creator_v2.py
@@ -121,9 +121,7 @@ class CreatorFrontendV2:
         if isinstance(result, HttpResponse):
             return result
         with tempfile.TemporaryDirectory() as tmp_dir:
-            tar_file = CreatorBackend(Path(tmp_dir)).devfile(
-                **result.body,  # type: ignore[arg-type]
-            )
+            tar_file = CreatorBackend(Path(tmp_dir)).devfile()
             response = self._response_from_tar(tar_file)
 
         return validate_response(
@@ -218,16 +216,12 @@ class CreatorBackend:
         create_tar_file(init_path, tar_file)
         return tar_file
 
-    def devfile(self, collection: str) -> Path:
+    def devfile(self) -> Path:
         """Scaffold a devfile.
-
-        Args:
-            collection: The collection name.
-
         Returns:
             The tar file path.
         """
-        # Path where the devfile will be added in the collection
+        # Path where the devfile will be added
         add_path = self.tmp_dir / "devfile"
         add_path.mkdir(parents=True, exist_ok=True)
 

--- a/src/ansible_dev_tools/resources/server/creator_v2.py
+++ b/src/ansible_dev_tools/resources/server/creator_v2.py
@@ -218,6 +218,7 @@ class CreatorBackend:
 
     def devfile(self) -> Path:
         """Scaffold a devfile.
+
         Returns:
             The tar file path.
         """

--- a/src/ansible_dev_tools/resources/server/creator_v2.py
+++ b/src/ansible_dev_tools/resources/server/creator_v2.py
@@ -10,8 +10,8 @@ from pathlib import Path
 from ansible_creator._version import version as creator_version
 from ansible_creator.config import Config
 from ansible_creator.output import Output
-from ansible_creator.subcommands.init import Init
 from ansible_creator.subcommands.add import Add
+from ansible_creator.subcommands.init import Init
 from ansible_creator.utils import TermFeatures
 from django.core.files.storage import FileSystemStorage
 from django.http import FileResponse, HttpRequest, HttpResponse
@@ -104,7 +104,7 @@ class CreatorFrontendV2:
             request=request,
             response=response,
         )
-   
+
     def devfile(
         self,
         request: HttpRequest,
@@ -130,8 +130,6 @@ class CreatorFrontendV2:
             request=request,
             response=response,
         )
-
-
 
 
 class CreatorOutput(Output):
@@ -220,7 +218,6 @@ class CreatorBackend:
         create_tar_file(init_path, tar_file)
         return tar_file
 
-
     def devfile(self, project: str, collection: str) -> Path:
         """Scaffold a devfile.
 
@@ -233,7 +230,7 @@ class CreatorBackend:
             The tar file path.
         """
         # Path where the devfile will be added in the collection
-        add_path= self.tmp_dir / collection
+        add_path = self.tmp_dir / collection
 
         config = Config(
             resource_type="devfile",

--- a/src/ansible_dev_tools/resources/server/creator_v2.py
+++ b/src/ansible_dev_tools/resources/server/creator_v2.py
@@ -236,7 +236,7 @@ class CreatorBackend:
             resource_type="devfile",
             project=project,
             creator_version=creator_version,
-            add_path=str(add_path),
+            path=str(add_path),
             output=CreatorOutput(log_file=str(self.tmp_dir / "creator.log")),
             collection=collection,
             subcommand="add",

--- a/src/ansible_dev_tools/resources/server/data/openapi.yaml
+++ b/src/ansible_dev_tools/resources/server/data/openapi.yaml
@@ -105,12 +105,6 @@ paths:
   /v2/creator/devfile:
     post:
       summary: Create a new devfile project
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/CreatorDevfile"
-        required: true
       responses:
         "201":
           description: Created
@@ -167,12 +161,6 @@ components:
         collection_name:
           type: string
         namespace:
-          type: string
-    CreatorDevfile:
-      type: object
-      additionalProperties: false
-      properties:
-        collection:
           type: string
     Error:
       type: object

--- a/src/ansible_dev_tools/resources/server/data/openapi.yaml
+++ b/src/ansible_dev_tools/resources/server/data/openapi.yaml
@@ -175,7 +175,7 @@ components:
         collection:
           type: string
         project:
-          type: string  
+          type: string
     Error:
       type: object
       properties:

--- a/src/ansible_dev_tools/resources/server/data/openapi.yaml
+++ b/src/ansible_dev_tools/resources/server/data/openapi.yaml
@@ -174,8 +174,6 @@ components:
       properties:
         collection:
           type: string
-        project:
-          type: string
     Error:
       type: object
       properties:

--- a/src/ansible_dev_tools/resources/server/data/openapi.yaml
+++ b/src/ansible_dev_tools/resources/server/data/openapi.yaml
@@ -102,6 +102,28 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /v2/creator/devfile:
+    post:
+      summary: Create a new devfile project
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreatorDevfile"
+        required: true
+      responses:
+        "201":
+          description: Created
+          content:
+            application/tar:
+              schema:
+                AnyValue: {}
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 
 components:
   schemas:
@@ -146,6 +168,14 @@ components:
           type: string
         namespace:
           type: string
+    CreatorDevfile:
+      type: object
+      additionalProperties: false
+      properties:
+        collection:
+          type: string
+        project:
+          type: string  
     Error:
       type: object
       properties:

--- a/src/ansible_dev_tools/subcommands/server.py
+++ b/src/ansible_dev_tools/subcommands/server.py
@@ -27,6 +27,7 @@ urlpatterns = (
     path(route="v1/creator/collection", view=CreatorFrontendV1().collection),
     path(route="v2/creator/playbook", view=CreatorFrontendV2().playbook),
     path(route="v2/creator/collection", view=CreatorFrontendV2().collection),
+    path(route="v2/creator/devfile", view=CreatorFrontendV2().devfile),
 )
 
 

--- a/tests/integration/test_server_creator_v2.py
+++ b/tests/integration/test_server_creator_v2.py
@@ -79,3 +79,25 @@ def test_collection_v2(server_url: str, tmp_path: Path) -> None:
         tar_file.write(response.content)
     with tarfile.open(dest_file) as file:
         assert "./roles/run/tasks/main.yml" in file.getnames()
+ 
+def test_devfile_v2(server_url: str, tmp_path: Path) -> None:
+    """Test the devfile creation.
+
+    Args:
+        server_url: The server URL.
+        tmp_path: Pytest tmp_path fixture.
+    """
+    response = requests.post(
+        f"{server_url}/v2/creator/devfile",
+        json={},
+        timeout=10,
+    )
+    assert response.status_code == requests.codes.get("created")
+    assert response.headers["Content-Disposition"] == 'attachment; filename="devfile.tar"'
+    assert response.headers["Content-Type"] == "application/tar"
+    dest_file = tmp_path / "devfile.tar"
+    with dest_file.open(mode="wb") as tar_file:
+        tar_file.write(response.content)
+    with tarfile.open(dest_file) as file:
+        assert "./devfile.yaml" in file.getnames()
+ 

--- a/tests/integration/test_server_creator_v2.py
+++ b/tests/integration/test_server_creator_v2.py
@@ -79,7 +79,8 @@ def test_collection_v2(server_url: str, tmp_path: Path) -> None:
         tar_file.write(response.content)
     with tarfile.open(dest_file) as file:
         assert "./roles/run/tasks/main.yml" in file.getnames()
- 
+
+
 def test_devfile_v2(server_url: str, tmp_path: Path) -> None:
     """Test the devfile creation.
 
@@ -100,4 +101,3 @@ def test_devfile_v2(server_url: str, tmp_path: Path) -> None:
         tar_file.write(response.content)
     with tarfile.open(dest_file) as file:
         assert "./devfile.yaml" in file.getnames()
- 

--- a/tests/integration/test_server_creator_v2.py
+++ b/tests/integration/test_server_creator_v2.py
@@ -32,7 +32,6 @@ def test_error_devfile_v2(server_url: str) -> None:
 
     Args:
         server_url: The server URL.
-        resource: The resource to test.
 
     Raises:
         AssertionError: If the test assertions fail (e.g., response status code or tar content).

--- a/tests/integration/test_server_creator_v2.py
+++ b/tests/integration/test_server_creator_v2.py
@@ -37,9 +37,11 @@ def test_error_devfile_v2(server_url: str) -> None:
     Raises:
         AssertionError: If the test assertions fail (e.g., response status code or tar content).
     """
-    #To simulate an error, we are sending the request with the get method as the api works with empty request body as well.
+    # To simulate an error, we are sending the request with the get method as the api works with empty request body as well.
     response = requests.get(f"{server_url}/v2/creator/devfile", timeout=10)
-    assert response.status_code == requests.codes.get("bad_request"),f"Expected 400 but got {response.status_code}"
+    assert response.status_code == requests.codes.get("bad_request"), (
+        f"Expected 400 but got {response.status_code}"
+    )
     assert response.text == "Operation get not found for " + f"{server_url}/v2/creator/devfile"
 
 

--- a/tests/integration/test_server_creator_v2.py
+++ b/tests/integration/test_server_creator_v2.py
@@ -27,6 +27,22 @@ def test_error_v2(server_url: str, resource: str) -> None:
     assert response.text == "Missing required request body"
 
 
+def test_error_devfile_v2(server_url: str) -> None:
+    """Test the error response when a request body is sent unexpectedly.
+
+    Args:
+        server_url: The server URL.
+        resource: The resource to test.
+
+    Raises:
+        AssertionError: If the test assertions fail (e.g., response status code or tar content).
+    """
+    #To simulate an error, we are sending the request with the get method as the api works with empty request body as well.
+    response = requests.get(f"{server_url}/v2/creator/devfile", timeout=10)
+    assert response.status_code == requests.codes.get("bad_request"),f"Expected 400 but got {response.status_code}"
+    assert response.text == "Operation get not found for " + f"{server_url}/v2/creator/devfile"
+
+
 def test_playbook_v2(server_url: str, tmp_path: Path) -> None:
     """Test the playbook creation.
 
@@ -87,6 +103,9 @@ def test_devfile_v2(server_url: str, tmp_path: Path) -> None:
     Args:
         server_url: The server URL.
         tmp_path: Pytest tmp_path fixture.
+
+    Raises:
+        AssertionError: If the test assertions fail (e.g., response status code or tar content).
     """
     response = requests.post(
         f"{server_url}/v2/creator/devfile",


### PR DESCRIPTION
1- Description: The implementation is to add an endpoint for devfile scaffolding. The supporting pytest cases are also added.
To execute the API: curl -X POST -O -J --max-time 10 "http://localhost:8000/v2/creator/devfile"
On a successful execution of the above command, you can expect a devfile.tar to be created under in the root of the folder.
2- Work Item link: https://issues.redhat.com/browse/AAP-36964

