### PR TITLE
Fix the publish workflow

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -127,6 +127,8 @@ jobs:
       - name: Create a new branch, update the file and push the branch
         if: github.event_name == 'release' && github.event.action == 'published'
         run: |
+          git config --global user.name "ansibuddy"
+          git config --global user.email "ansible-devtools@redhat.com"
           cd ansible-devspaces-demo
           git checkout -b update-devspaces-image-${{ github.event.release.tag_name }}
           export SHA=$(docker manifest inspect -v ghcr.io/ansible/ansible-devspaces:latest | jq -r '[.Descriptor.digest][0]')


### PR DESCRIPTION
This PR fixes the identity (name/email) issue for git commands being run during the `publish-devspaces` job.

Related PR: https://github.com/ansible/ansible-dev-tools/pull/558

Related failure: https://github.com/ansible/ansible-dev-tools/actions/runs/14708074756/job/41274839763