### PR TITLE
Ensure GITHUB_TOKEN is passed correctly

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -126,6 +126,8 @@ jobs:
 
       - name: Create a new branch, update the file and push the branch
         if: github.event_name == 'release' && github.event.action == 'published'
+        env:
+          GITHUB_TOKEN: ${{ secrets.ANSIBUDDY_BOT_PAT }}
         run: |
           git config --global user.name "ansibuddy"
           git config --global user.email "ansible-devtools@redhat.com"


### PR DESCRIPTION
Update the workflow to ensure that the necessary GITHUB_TOKEN authentication is passed in the workflow.

Related PR: https://github.com/ansible/ansible-dev-tools/pull/564 and https://github.com/ansible/ansible-dev-tools/pull/558

Related failure: https://github.com/ansible/ansible-dev-tools/actions/runs/14745121248/job/41391256895