### PR TITLE
Chore: Fix pydoclint DOC502 errors in test_server_creator_v2.py

### DIFF
--- a/.config/pydoclint-baseline.txt
+++ b/.config/pydoclint-baseline.txt
@@ -1,4 +1,0 @@
-tests/integration/test_server_creator_v2.py
-    DOC502: Function `test_error_devfile_v2` has a "Raises" section in the docstring, but there are not "raise" statements in the body
-    DOC502: Function `test_devfile_v2` has a "Raises" section in the docstring, but there are not "raise" statements in the body
---------------------

--- a/tests/integration/test_server_creator_v2.py
+++ b/tests/integration/test_server_creator_v2.py
@@ -32,9 +32,6 @@ def test_error_devfile_v2(server_url: str) -> None:
 
     Args:
         server_url: The server URL.
-
-    Raises:
-        AssertionError: If the test assertions fail (e.g., response status code or tar content).
     """
     # To simulate an error, we are sending the request with the get method as the api works with empty request body as well.
     response = requests.get(f"{server_url}/v2/creator/devfile", timeout=10)
@@ -104,9 +101,6 @@ def test_devfile_v2(server_url: str, tmp_path: Path) -> None:
     Args:
         server_url: The server URL.
         tmp_path: Pytest tmp_path fixture.
-
-    Raises:
-        AssertionError: If the test assertions fail (e.g., response status code or tar content).
     """
     response = requests.post(
         f"{server_url}/v2/creator/devfile",


### PR DESCRIPTION
## Fix pydoclint DOC502 errors in test_server_creator_v2.py

### Summary
This PR resolves pydoclint DOC502 errors by removing unnecessary "Raises" sections from test function docstrings.

### Changes Made
- **tests/integration/test_server_creator_v2.py**: Removed "Raises" sections from `test_error_devfile_v2()` and `test_devfile_v2()` docstrings
- **.config/pydoclint-baseline.txt**: Cleared the baseline file as the errors have been resolved

### Problem
The pydoclint tool was reporting DOC502 errors for two test functions that documented `AssertionError` in their "Raises" sections but only used `assert` statements without explicit `raise` statements. Pydoclint doesn't recognize that `assert` statements can implicitly raise `AssertionError`.

### Solution
Removed the "Raises" sections from both affected functions since:
1. Assert statements in test functions are implicit and don't typically need to be documented
2. This makes the docstrings consistent with other test functions in the same file
3. The docstrings remain clear and informative without the unnecessary "Raises" sections

### Testing
- The functions maintain their original behavior
- Pydoclint errors are resolved
- Docstring consistency is improved across the test file

This is a documentation-only change that doesn't affect functionality but improves code quality by resolving linting issues.