### PR TITLE
Remove pattern API endpoint

### DIFF
--- a/src/ansible_dev_tools/resources/server/creator_v2.py
+++ b/src/ansible_dev_tools/resources/server/creator_v2.py
@@ -129,27 +129,6 @@ class CreatorFrontendV2:
             response=response,
         )
 
-    def pattern(self, request: HttpRequest) -> FileResponse | HttpResponse:
-        """Add a pattern.
-
-        Args:
-            request: HttpRequest object.
-
-        Returns:
-            File or error response.
-        """
-        result = validate_request(request)
-        if isinstance(result, HttpResponse):
-            return result
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            tar_file = CreatorBackend(Path(tmp_dir)).pattern(**result.body)  # type: ignore[arg-type]
-            response = self._response_from_tar(tar_file)
-
-        return validate_response(
-            request=request,
-            response=response,
-        )
-
 
 class CreatorOutput(Output):
     """The creator output."""
@@ -257,31 +236,5 @@ class CreatorBackend:
         )
         Add(config).run()
         tar_file = self.tmp_dir / "devfile.tar"
-        create_tar_file(add_path, tar_file)
-        return tar_file
-
-    def pattern(self, pattern_name: str) -> Path:
-        """Scaffold a pattern.
-
-        Args:
-            pattern_name: Name of the pattern to add.
-
-        Returns:
-            The tar file path.
-        """
-        # Path where the pattern will be scaffolded.
-        add_path = self.tmp_dir / pattern_name
-        add_path.mkdir(parents=True, exist_ok=True)
-
-        config = Config(
-            creator_version=creator_version,
-            path=str(add_path),
-            output=CreatorOutput(log_file=str(self.tmp_dir / "creator.log")),
-            subcommand="add",
-            resource_type="pattern",
-            overwrite=True,
-        )
-        Add(config, skip_collection_check=True).run()
-        tar_file = self.tmp_dir / f"{pattern_name}.tar"
         create_tar_file(add_path, tar_file)
         return tar_file

--- a/src/ansible_dev_tools/resources/server/data/openapi.yaml
+++ b/src/ansible_dev_tools/resources/server/data/openapi.yaml
@@ -118,28 +118,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-  /v2/creator/pattern:
-    post:
-      summary: Add a pattern to an existing collection
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/CreatorPattern"
-        required: true
-      responses:
-        "201":
-          description: Created
-          content:
-            application/tar:
-              schema:
-                AnyValue: {}
-        "400":
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
 
 components:
   schemas:
@@ -163,12 +141,6 @@ components:
         collection:
           type: string
         project:
-          type: string
-    CreatorPattern:
-      type: object
-      additionalProperties: false
-      properties:
-        pattern_name:
           type: string
     CreatorPlaybook:
       type: object

--- a/src/ansible_dev_tools/subcommands/server.py
+++ b/src/ansible_dev_tools/subcommands/server.py
@@ -28,7 +28,6 @@ urlpatterns = (
     path(route="v2/creator/playbook", view=CreatorFrontendV2().playbook),
     path(route="v2/creator/collection", view=CreatorFrontendV2().collection),
     path(route="v2/creator/devfile", view=CreatorFrontendV2().devfile),
-    path(route="v2/creator/pattern", view=CreatorFrontendV2().pattern),
 )
 
 

--- a/tests/integration/test_server_creator_v2.py
+++ b/tests/integration/test_server_creator_v2.py
@@ -121,28 +121,3 @@ def test_devfile_v2(server_url: str, tmp_path: Path) -> None:
         tar_file.write(response.content)
     with tarfile.open(dest_file) as file:
         assert "./devfile.yaml" in file.getnames()
-
-
-def test_pattern_v2(server_url: str, tmp_path: Path) -> None:
-    """Test the pattern creation.
-
-    Args:
-        server_url: The server URL.
-        tmp_path: Pytest tmp_path fixture.
-    """
-    pattern_name = "foo"
-    response = requests.post(
-        f"{server_url}/v2/creator/pattern",
-        json={
-            "pattern_name": pattern_name,
-        },
-        timeout=10,
-    )
-    assert response.status_code == requests.codes.get("created")
-    assert response.headers["Content-Disposition"] == f'attachment; filename="{pattern_name}.tar"'
-    assert response.headers["Content-Type"] == "application/tar"
-    dest_file = tmp_path / f"{pattern_name}.tar"
-    with dest_file.open(mode="wb") as tar_file:
-        tar_file.write(response.content)
-    with tarfile.open(dest_file) as file:
-        assert "./extensions" in file.getnames()


### PR DESCRIPTION
Removes the `add pattern` API endpoint.

Reverts #587.

See https://issues.redhat.com/browse/AAP-53645