### PR TITLE
chore: fix release-drafter v7 extends command

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,6 +1,6 @@
 ---
 # see https://github.com/ansible/team-devtools
-_extends: ansible/team-devtools
+_extends: github:ansible/team-devtools/.github/release-drafter.yml
 autolabeler:
   - label: "skip-changelog"
     title:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ default_language_version:
   # minimal version determined by minimal version required by ansible-core, but
   # we might keep a backwards compatibility version for older ones
   python: "3.11"
+  node: "24"
 repos:
   - repo: meta
     hooks:
@@ -33,6 +34,8 @@ repos:
         priority: 1
       - id: cspell
         priority: 0
+        language_version: "24"
+        language: node
       - id: pylint
         priority: 5
       - id: codecov


### PR DESCRIPTION
This should fix the release drafter update of the changelog on push as newer versions
seems to require a different syntax for use of `_extends`.

Related: https://github.com/ansible/ansible-dev-tools/actions/runs/24027708921/job/70069689565
