### PR TITLE
fix: devspaces rootless podman, sudo, prompt hostname, and EE example

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -2,6 +2,7 @@ Ansibuddy
 BUILDAH
 Containerfile
 Devfile
+NOPASSWD
 PKGMGR
 Unmarshal
 accesslog
@@ -25,7 +26,6 @@ lightspeed
 microdnf
 modifyitems
 netcommon
-nopasswd
 pinentry
 prek
 pylibssh

--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -25,6 +25,7 @@ lightspeed
 microdnf
 modifyitems
 netcommon
+nopasswd
 pinentry
 prek
 pylibssh

--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -1,6 +1,7 @@
 Ansibuddy
 BUILDAH
 Containerfile
+DEVWORKSPACE
 Devfile
 NOPASSWD
 PKGMGR

--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -26,6 +26,7 @@ lightspeed
 microdnf
 modifyitems
 netcommon
+nopasswd
 pinentry
 prek
 pylibssh

--- a/devspaces/Containerfile
+++ b/devspaces/Containerfile
@@ -1,6 +1,7 @@
 FROM quay.io/devfile/base-developer-image:ubi9-latest
 
 ARG PYV=3.12
+ARG ENABLE_NOPASSWD_SUDO=true
 
 LABEL org.opencontainers.image.source=https://github.com/ansible/ansible-dev-tools
 LABEL org.opencontainers.image.authors="Ansible DevTools"
@@ -11,7 +12,7 @@ LABEL org.opencontainers.image.description="An OpenShift Dev Spaces container im
 USER 0
 
 WORKDIR /context
-RUN --mount=type=bind,target=. --mount=type=cache,dst=/var/cache/dnf --mount=type=cache,dst=/root/.cache/pip ./setup.sh
+RUN --mount=type=bind,target=. --mount=type=cache,dst=/var/cache/dnf --mount=type=cache,dst=/root/.cache/pip ENABLE_NOPASSWD_SUDO="${ENABLE_NOPASSWD_SUDO}" ./setup.sh
 
 ENV BUILDAH_ISOLATION=chroot
 

--- a/devspaces/context/ansible-prompt.sh
+++ b/devspaces/context/ansible-prompt.sh
@@ -53,8 +53,16 @@ _adt_build_prompt() {
         status_indicator="${red}[${last_exit}]${reset} "
     fi
 
+    local host_label_raw
     local host_label
-    host_label="${ADT_PROMPT_HOST:-${DEVWORKSPACE_NAME:-\h}}"
+    host_label_raw="${ADT_PROMPT_HOST:-${DEVWORKSPACE_NAME:-}}"
+    if [[ -n "$host_label_raw" ]]; then
+        host_label=${host_label_raw//\\/\\\\}
+        host_label=${host_label//\$/\\$}
+        host_label=${host_label//\`/\\\`}
+    else
+        host_label='\h'
+    fi
 
     PS1="${status_indicator}${prefix}${bold}${green}\u@${host_label}${reset}:${bold}${blue}\w${reset}\$(_adt_git_branch)\$ "
 }

--- a/devspaces/context/ansible-prompt.sh
+++ b/devspaces/context/ansible-prompt.sh
@@ -53,7 +53,10 @@ _adt_build_prompt() {
         status_indicator="${red}[${last_exit}]${reset} "
     fi
 
-    PS1="${status_indicator}${prefix}${bold}${green}\u@\h${reset}:${bold}${blue}\w${reset}\$(_adt_git_branch)\$ "
+    local host_label
+    host_label="${ADT_PROMPT_HOST:-${DEVWORKSPACE_NAME:-\h}}"
+
+    PS1="${status_indicator}${prefix}${bold}${green}\u@${host_label}${reset}:${bold}${blue}\w${reset}\$(_adt_git_branch)\$ "
 }
 
 # Preserve any existing PROMPT_COMMAND hooks

--- a/devspaces/context/entrypoint.sh
+++ b/devspaces/context/entrypoint.sh
@@ -25,7 +25,7 @@ START_ID=$(( CURRENT_UID + 1 ))
 # Derive the available subordinate ID count from the UID namespace mapping
 # (same count used for both subuid and subgid).
 if [ -r /proc/self/uid_map ]; then
-    NAMESPACE_SIZE=$(awk '{print $3}' /proc/self/uid_map | head -n1)
+    NAMESPACE_SIZE=$(awk '{s+=$3} END{print s}' /proc/self/uid_map)
 else
     NAMESPACE_SIZE=65536
 fi

--- a/devspaces/context/entrypoint.sh
+++ b/devspaces/context/entrypoint.sh
@@ -25,7 +25,7 @@ START_ID=$(( CURRENT_UID + 1 ))
 # Derive the available subordinate ID count from the UID namespace mapping
 # (same count used for both subuid and subgid).
 if [ -r /proc/self/uid_map ]; then
-    NAMESPACE_SIZE=$(awk '{s+=$3} END{print s}' /proc/self/uid_map)
+    NAMESPACE_SIZE=$(awk '{end=$1 + $3; if (end > max) max = end} END{print max}' /proc/self/uid_map)
 else
     NAMESPACE_SIZE=65536
 fi

--- a/devspaces/context/setup.sh
+++ b/devspaces/context/setup.sh
@@ -50,8 +50,10 @@ setcap cap_setgid+ep /usr/bin/newgidmap
 touch /etc/subgid /etc/subuid
 chown 0:0 /etc/subgid /etc/subuid
 
-echo "%wheel ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/wheel-nopasswd
-chmod 0440 /etc/sudoers.d/wheel-nopasswd
+if [[ "${ENABLE_NOPASSWD_SUDO:-false}" == "true" ]]; then
+    echo "%wheel ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/wheel-nopasswd
+    chmod 0440 /etc/sudoers.d/wheel-nopasswd
+fi
 
 chgrp -R 0 /home && chmod -R g=u /etc/passwd /etc/group /etc/subuid /etc/subgid /home
 

--- a/devspaces/context/setup.sh
+++ b/devspaces/context/setup.sh
@@ -50,6 +50,9 @@ setcap cap_setgid+ep /usr/bin/newgidmap
 touch /etc/subgid /etc/subuid
 chown 0:0 /etc/subgid /etc/subuid
 
+echo "%wheel ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/wheel-nopasswd
+chmod 0440 /etc/sudoers.d/wheel-nopasswd
+
 chgrp -R 0 /home && chmod -R g=u /etc/passwd /etc/group /etc/subuid /etc/subgid /home
 
 # Install the colored bash prompt

--- a/docs/examples/requirements.txt
+++ b/docs/examples/requirements.txt
@@ -1,1 +1,1 @@
-ansible-pylibssh==1.1.0
+ansible-pylibssh>=1.4.0


### PR DESCRIPTION
## Summary
- Fix entrypoint.sh uid_map parsing so the container starts correctly under rootless Podman.
- Enable passwordless sudo for the `wheel` group, gated behind an `ENABLE_NOPASSWD_SUDO` build arg (default: `true`).
- Shorten the bash prompt hostname in Dev Spaces by using `DEVWORKSPACE_NAME` instead of the long pod hostname.
- Fix ansible-pylibssh version conflict in the EE build example.

## Changes
- **`devspaces/context/entrypoint.sh`**: Compute the UID namespace upper bound as `max($1 + $3)` across all `/proc/self/uid_map` lines, instead of only reading the first line. Fixes `No subordinate IDs available` error under rootless Podman.
- **`devspaces/context/setup.sh`**: Add passwordless sudo for `%wheel` via `/etc/sudoers.d/wheel-nopasswd`, gated behind `ENABLE_NOPASSWD_SUDO` env var (can be disabled with `--build-arg ENABLE_NOPASSWD_SUDO=false`).
- **`devspaces/Containerfile`**: Add `ENABLE_NOPASSWD_SUDO` build arg (default: `true`) and pass it to `setup.sh`.
- **`devspaces/context/ansible-prompt.sh`**: Use `DEVWORKSPACE_NAME` (from devfile `metadata.name`) as the prompt hostname in Dev Spaces, with `ADT_PROMPT_HOST` as an override. Falls back to `\h` for local use. The host label is escaped to prevent command injection via PS1.
- **`docs/examples/requirements.txt`**: Update `ansible-pylibssh==1.1.0` to `>=1.4.0` to resolve pip conflict with the base image which requires `==1.4.0`.
- **`.config/dictionary.txt`**: Add `DEVWORKSPACE`, `NOPASSWD`/`nopasswd` to cspell dictionary.

## Impact
- No change in behavior on Dev Spaces (OpenShift) for the uid_map fix — single-line uid_map produces the same result.
- Fixes running the container locally with rootless Podman where uid_map has multiple lines.
- Prompt in Dev Spaces now shows `user@ansible-demo:~$` instead of the long pod hostname.
- EE example builds successfully again.

## Test plan
- [x] Verified `podman run` with fixed entrypoint succeeds locally
- [x] Built the image locally and confirmed uid_map calculation and sudo work
- [ ] Verify container starts correctly in Dev Spaces (OpenShift)
- [ ] Verify `sudo` works without password prompt inside the container
- [ ] Verify prompt shows `DEVWORKSPACE_NAME` in Dev Spaces
- [ ] Verify EE example builds with `ansible-builder build`