### PR TITLE
fix: add runtime user to wheel group for passwordless sudo in devspaces

### DIFF
--- a/devspaces/context/entrypoint.sh
+++ b/devspaces/context/entrypoint.sh
@@ -22,8 +22,8 @@ USER=$(whoami)
 CURRENT_UID=$(id -u)
 START_ID=$(( CURRENT_UID + 1 ))
 
-# Ensure user is in the wheel group for passwordless sudo.
-# usermod requires root, so edit /etc/group directly (made writable by setup.sh).
+# Ensure user is in the wheel group for NOPASSWD sudo.
+# Edit /etc/group directly as usermod requires root (made writable by setup.sh).
 if [ -w /etc/group ] && ! id -nG "$USER" 2>/dev/null | grep -qw wheel; then
     sed -i "s/^\(wheel:x:[0-9]*:.*\)/\1,${USER}/; s/:,/:/" /etc/group
 fi

--- a/devspaces/context/entrypoint.sh
+++ b/devspaces/context/entrypoint.sh
@@ -2,7 +2,7 @@
 # Entrypoint for the Ansible Dev Spaces container image.
 # Sets up the dynamic UID mapping required for rootless podman
 # with user namespaces (container-in-container without kubedock).
-# cspell: ignore subuid subgid catatonit
+# cspell: ignore subuid subgid catatonit usermod
 set -euo pipefail
 
 if [ ! -d "${HOME}" ]; then
@@ -21,6 +21,11 @@ fi
 USER=$(whoami)
 CURRENT_UID=$(id -u)
 START_ID=$(( CURRENT_UID + 1 ))
+
+# Ensure user is in the wheel group for passwordless sudo
+if [ -w /etc/group ] && ! id -nG "$USER" 2>/dev/null | grep -qw wheel; then
+    usermod -aG wheel "$USER" 2>/dev/null || true
+fi
 
 # Derive the available subordinate ID count from the UID namespace mapping
 # (same count used for both subuid and subgid).

--- a/devspaces/context/entrypoint.sh
+++ b/devspaces/context/entrypoint.sh
@@ -23,9 +23,12 @@ CURRENT_UID=$(id -u)
 START_ID=$(( CURRENT_UID + 1 ))
 
 # Ensure user is in the wheel group for NOPASSWD sudo.
-# Edit /etc/group directly as usermod requires root (made writable by setup.sh).
+# Use a temp file + cat to avoid sed -i which needs a writable /etc directory.
 if [ -w /etc/group ] && ! id -nG "$USER" 2>/dev/null | grep -qw wheel; then
-    sed -i "s/^\(wheel:x:[0-9]*:.*\)/\1,${USER}/; s/:,/:/" /etc/group
+    _tmp=$(mktemp)
+    awk -F: -v u="$USER" '$1=="wheel"{$4=($4==""?u:$4","u)} {print $1":"$2":"$3":"$4}' /etc/group >"$_tmp"
+    cat "$_tmp" >/etc/group
+    rm -f "$_tmp"
 fi
 
 # Derive the available subordinate ID count from the UID namespace mapping

--- a/devspaces/context/entrypoint.sh
+++ b/devspaces/context/entrypoint.sh
@@ -2,7 +2,7 @@
 # Entrypoint for the Ansible Dev Spaces container image.
 # Sets up the dynamic UID mapping required for rootless podman
 # with user namespaces (container-in-container without kubedock).
-# cspell: ignore subuid subgid catatonit usermod
+# cspell: ignore subuid subgid catatonit
 set -euo pipefail
 
 if [ ! -d "${HOME}" ]; then
@@ -22,9 +22,10 @@ USER=$(whoami)
 CURRENT_UID=$(id -u)
 START_ID=$(( CURRENT_UID + 1 ))
 
-# Ensure user is in the wheel group for passwordless sudo
+# Ensure user is in the wheel group for passwordless sudo.
+# usermod requires root, so edit /etc/group directly (made writable by setup.sh).
 if [ -w /etc/group ] && ! id -nG "$USER" 2>/dev/null | grep -qw wheel; then
-    usermod -aG wheel "$USER" 2>/dev/null || true
+    sed -i "s/^\(wheel:x:[0-9]*:.*\)/\1,${USER}/; s/:,/:/" /etc/group
 fi
 
 # Derive the available subordinate ID count from the UID namespace mapping


### PR DESCRIPTION
## Summary
- Add the dynamically created user to the `wheel` group at runtime in `entrypoint.sh`, so the `NOPASSWD` sudoers rule from #728 actually takes effect.

## Problem
PR #728 added NOPASSWD sudo by creating `/etc/sudoers.d/wheel-nopasswd` with `%wheel ALL=(ALL) NOPASSWD: ALL`. However, in Dev Spaces, OpenShift assigns an arbitrary UID and the user is created dynamically in `entrypoint.sh` — but was never added to the `wheel` group. As a result, `sudo` still prompted for a password.

## Changes
- **`devspaces/context/entrypoint.sh`**: After resolving the user identity, check if the user is already in the `wheel` group; if not, append them to the `wheel` line in `/etc/group` using `awk` with a temp file (avoids `sed -i` which requires `/etc` directory write access, and `usermod` which requires root).

## Test plan
- [ ] Start a Dev Spaces workspace and verify `sudo whoami` returns `root` with no password prompt
- [ ] Verify `id` shows `wheel` in the groups list
- [ ] Verify local `podman run` still works correctly

Fixes #729