### PR TITLE
Update Dev Spaces image to support sudo

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -12,6 +12,8 @@ components:
       env:
         - name: "ANSIBLE_COLLECTIONS_PATH"
           value: "~/.ansible/collections:/usr/share/ansible/collections:/projects/ansible-devspaces-demo/collections"
+        - name: "ADT_CONTAINER_ENGINE"
+          value: "podman"
 commands:
   - id: molecule-create
     exec:

--- a/devspaces/Containerfile
+++ b/devspaces/Containerfile
@@ -16,7 +16,8 @@ RUN --mount=type=bind,target=. --mount=type=cache,dst=/var/cache/dnf --mount=typ
 
 ENV BUILDAH_ISOLATION=chroot
 
-USER 10001
+# Reflect the UID that the SCC will force the workspace to run as.
+USER 1000
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["tail", "-f", "/dev/null"]

--- a/devspaces/context/setup.sh
+++ b/devspaces/context/setup.sh
@@ -50,12 +50,15 @@ setcap cap_setgid+ep /usr/bin/newgidmap
 touch /etc/subgid /etc/subuid
 chown 0:0 /etc/subgid /etc/subuid
 # Remove the base image entries for user
-userdel user
-# Add the user with the UID that the SCC will enforce
-useradd -u 1000 -G wheel,root -d /home/user --shell /bin/bash -m user
-chmod 600 /etc/shadow
-echo "user:*:0:0:99999:7:::" >> /etc/shadow
-chown -R user /home/user
+if id user >/dev/null 2>&1
+then
+  userdel user
+  # Add the user with the UID that the SCC will enforce
+  useradd -u 1000 -G wheel,root -d /home/user --shell /bin/bash -m user
+  usermod -L user
+  chmod 400 /etc/shadow
+  chown -R user /home/user
+fi
 
 if [[ "${ENABLE_NOPASSWD_SUDO:-false}" == "true" ]]; then
     echo "%wheel ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/wheel-nopasswd

--- a/devspaces/context/setup.sh
+++ b/devspaces/context/setup.sh
@@ -49,6 +49,13 @@ setcap cap_setuid+ep /usr/bin/newuidmap
 setcap cap_setgid+ep /usr/bin/newgidmap
 touch /etc/subgid /etc/subuid
 chown 0:0 /etc/subgid /etc/subuid
+# Remove the base image entries for user
+userdel user
+# Add the user with the UID that the SCC will enforce
+useradd -u 1000 -G wheel,root -d /home/user --shell /bin/bash -m user
+chmod 600 /etc/shadow
+echo "user:*:0:0:99999:7:::" >> /etc/shadow
+chown -R user /home/user
 
 if [[ "${ENABLE_NOPASSWD_SUDO:-false}" == "true" ]]; then
     echo "%wheel ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/wheel-nopasswd


### PR DESCRIPTION
fix: Fixes sudo execution in the Dev Spaces workspace image

Added logic to remove the `user` entry with `uid` `10001`.  This user is injected by the base image that this image is built from.  The presence of that user entry results in duplicate entries in `/etc/passwd` and `/etc/group`.  The duplicate entries prevent `sudo` from working properly since `uid` `1000` is not resolved as belonging to the `wheel` group.

Added an entry to `/etc/shadow` for the user.  This prevents the PAM errors when executing `sudo`

Changed the `USER` entry in the Containerfile to `1000`.  This change has no runtime effect.  It is for reference.

Added the env var `ADT_CONTAINER_ENGINE=podman` to the devfile.yaml.  This enables using `podman` in the Dev Spaces workspace for `tox`