### PR TITLE
fix: devspaces sudo support with correct UID and user setup

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -39,4 +39,5 @@ skopeo
 unmarshal
 unmarshalling
 urandom
+userdel
 userns

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -12,6 +12,8 @@ components:
       env:
         - name: "ANSIBLE_COLLECTIONS_PATH"
           value: "~/.ansible/collections:/usr/share/ansible/collections:/projects/ansible-devspaces-demo/collections"
+        - name: "ADT_CONTAINER_ENGINE"
+          value: "podman"
 commands:
   - id: molecule-create
     exec:

--- a/devspaces/Containerfile
+++ b/devspaces/Containerfile
@@ -16,7 +16,8 @@ RUN --mount=type=bind,target=. --mount=type=cache,dst=/var/cache/dnf --mount=typ
 
 ENV BUILDAH_ISOLATION=chroot
 
-USER 10001
+# Reflect the UID that the SCC will force the workspace to run as.
+USER 1000
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["tail", "-f", "/dev/null"]

--- a/devspaces/context/setup.sh
+++ b/devspaces/context/setup.sh
@@ -49,6 +49,16 @@ setcap cap_setuid+ep /usr/bin/newuidmap
 setcap cap_setgid+ep /usr/bin/newgidmap
 touch /etc/subgid /etc/subuid
 chown 0:0 /etc/subgid /etc/subuid
+# Remove the base image entries for user
+if id user >/dev/null 2>&1
+then
+  userdel user
+  # Add the user with the UID that the SCC will enforce
+  useradd -u 1000 -G wheel,root -d /home/user --shell /bin/bash -m user
+  usermod -L user
+  chmod 400 /etc/shadow
+  chown -R user /home/user
+fi
 
 if [[ "${ENABLE_NOPASSWD_SUDO:-false}" == "true" ]]; then
     echo "%wheel ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/wheel-nopasswd

--- a/devspaces/context/setup.sh
+++ b/devspaces/context/setup.sh
@@ -54,7 +54,10 @@ if id user >/dev/null 2>&1
 then
   userdel user
   # Add the user with the UID that the SCC will enforce
-  useradd -u 1000 -G wheel,root -d /home/user --shell /bin/bash -m user
+  if ! useradd -u 1000 -G wheel,root -d /home/user --shell /bin/bash -m user; then
+    echo "ERROR: Failed to create user with UID 1000" >&2
+    exit 1
+  fi
   usermod -L user
   chmod 400 /etc/shadow
   chown -R user /home/user


### PR DESCRIPTION
## Summary

- Remove injected base image `user` (uid 10001) and recreate with uid 1000 to match the SCC-enforced UID, fixing duplicate `/etc/passwd` and `/etc/group` entries that prevented `sudo` from working
- Lock the user account (`usermod -L`) and set `/etc/shadow` permissions to avoid PAM errors in the workspace container
- Add `ADT_CONTAINER_ENGINE=podman` env var to `devfile.yaml` for tox podman support
- Guard `userdel` with `id` check so the build doesn't break if the base image drops the `user` account

Based on work by @cgruver in #734 (closed due to GPG signing issues). Incorporates all review feedback from that PR.

## Test plan

- [ ] Build the devspaces container image (`tox -e devspaces`)
- [ ] Launch a Dev Spaces workspace with the built image
- [ ] Verify `sudo` works without password prompts
- [ ] Verify `podman` works inside the workspace
- [ ] Verify no duplicate entries in `/etc/passwd` and `/etc/group`