### PR TITLE
chore: bump devel environment to python 3.13

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -36,7 +36,7 @@ jobs:
       run_pre: ./tools/test-setup.sh
       min_python: "3.11"
       max_python: "3.13"
-      default_python: "3.12" # min version of `devel`
+      default_python: "3.13" # min version of `devel`
       jobs_producing_coverage: 9
       other_names_also: |
         devspaces

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -508,6 +508,7 @@ env_dir = "{work_dir}/lint"
 skip_install = true
 
 [tool.tox.env.devel]
+base_python = "python3.13"
 dependency_groups = ["dev"]
 deps = [
   "ansible-compat@ git+https://github.com/ansible/ansible-compat.git",


### PR DESCRIPTION
## Summary
- Update the devel tox environment to use Python 3.13 as the base interpreter
- Set `default_python` to 3.13 in the CI workflow to match the new minimum devel version
## Details
The devel environment should track the latest supported Python version. This change:
- Adds `base_python = "python3.13"` to `[tool.tox.env.devel]` in `pyproject.toml`
- Updates `default_python` from `"3.12"` to `"3.13"` in `.github/workflows/tox.yml`