### PR TITLE
fix(ci): pin pytest<9.1 in devel env for libtmux compat

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -519,6 +519,7 @@ deps = [
   "ansible-navigator@ git+https://github.com/ansible/ansible-navigator.git",
   "molecule@ git+https://github.com/ansible/molecule.git",
   "pytest-ansible@ git+https://github.com/ansible/pytest-ansible.git",
+  "pytest<9.1",  # libtmux applies marks to fixtures, blocked by pytest 9.1+ (https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function)
   "tox-ansible@ git+https://github.com/ansible/tox-ansible.git"
 ]
 runner = "uv-venv-runner"


### PR DESCRIPTION
libtmux's pytest plugin applies marks to fixtures, which pytest 9.1+ now rejects as a hard error. Pin pytest<9.1 in the devel env until libtmux removes the deprecated pattern.

See: https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function