### PR TITLE
fix: update base image to Fedora 44 as Fedora 42 is EOL

### DIFF
--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -3,7 +3,7 @@ version: 3
 
 images:
   base_image:
-    name: quay.io/fedora/fedora-minimal:42
+    name: quay.io/fedora/fedora-minimal:44
 
 dependencies:
   ansible_runner:


### PR DESCRIPTION
## Summary
Updates the execution environment base image from Fedora 42 to Fedora 44, as Fedora 42 has reached end-of-life.

## Problem
Fedora 42 is now EOL and no longer receiving security updates. Continuing to use it as a base image exposes users to unpatched security vulnerabilities.

## Solution
Updated `execution-environment.yml` to use `quay.io/fedora/fedora-minimal:44` instead of version 42.

This is a straightforward version bump with no breaking changes expected, as Fedora maintains backward compatibility between consecutive releases.

## Testing
The change is minimal - simply updating the base image version number. Fedora 44 is actively maintained and receives regular security patches.

Fixes #774

Assisted-by: Claude Opus 4.6