### PR TITLE
fix: add Renovate custom manager for Fedora base image tracking

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,15 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>ansible/actions//config/renovate.json"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["(^|/)execution-environment\\.yml$"],
+      "matchStrings": ["name:\\s*(?<depName>[^:]+):(?<currentValue>\\d+)"],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "loose"
+    }
+  ],
   "packageRules": [
     {
       "allowedVersions": "<2.17",


### PR DESCRIPTION
## Summary
Adds a Renovate `customManagers` entry to automatically detect new Fedora base image releases on quay.io and open PRs to bump the version in `execution-environment.yml`.

## Problem
The Fedora base image in `execution-environment.yml` has gone stale twice (#660, #774), leaving the project on an EOL Fedora version for weeks before someone notices. Renovate is already configured in this repo but only tracks Python packages — the container base image is not covered.

## Solution
Added a regex custom manager to `renovate.json` that:
- Matches the base image line in `execution-environment.yml`
- Uses the `docker` datasource to query `quay.io/fedora/fedora-minimal` for new tags
- Uses `loose` versioning to correctly order plain integer tags (`42`, `44`, etc.)

This extends the existing Renovate setup with no new tooling.

## Testing
The regex was verified against the actual file content — it correctly captures `depName` (`quay.io/fedora/fedora-minimal`) and `currentValue` (`44`) from the `name:` field.

Fixes #776

Assisted-by: Claude Opus 4.6