### PR TITLE
SonarCloud Fix: Extract duplicate string literal (S1192, src)

### DIFF
--- a/src/ansible_dev_tools/resources/server/creator_v2.py
+++ b/src/ansible_dev_tools/resources/server/creator_v2.py
@@ -185,6 +185,11 @@ class CreatorBackend:
         """
         self.tmp_dir = tmp_dir
 
+    @property
+    def _creator_output(self) -> CreatorOutput:
+        """Return a CreatorOutput configured for the current temp directory."""
+        return CreatorOutput(log_file=str(self.tmp_dir / "creator.log"))
+
     def collection(self, collection: str, project: str) -> Path:
         """Scaffold a collection.
 
@@ -199,7 +204,7 @@ class CreatorBackend:
         config = Config(
             creator_version=creator_version,
             init_path=str(init_path),
-            output=CreatorOutput(log_file=str(self.tmp_dir / "creator.log")),
+            output=self._creator_output,
             collection=collection,
             subcommand="init",
             project=project,
@@ -229,7 +234,7 @@ class CreatorBackend:
         config = Config(
             creator_version=creator_version,
             init_path=str(init_path),
-            output=CreatorOutput(log_file=str(self.tmp_dir / "creator.log")),
+            output=self._creator_output,
             project=project,
             namespace=namespace,
             collection_name=collection_name,
@@ -254,7 +259,7 @@ class CreatorBackend:
             resource_type="devfile",
             creator_version=creator_version,
             path=str(add_path),
-            output=CreatorOutput(log_file=str(self.tmp_dir / "creator.log")),
+            output=self._creator_output,
             subcommand="add",
             overwrite=True,
         )
@@ -273,7 +278,7 @@ class CreatorBackend:
         config = Config(
             creator_version=creator_version,
             init_path=str(init_path),
-            output=CreatorOutput(log_file=str(self.tmp_dir / "creator.log")),
+            output=self._creator_output,
             project="execution_env",
             subcommand="init",
         )


### PR DESCRIPTION
## Summary

Replace 4 duplicate `CreatorOutput(log_file=str(self.tmp_dir / "creator.log"))` expressions with a `_creator_output` property on `CreatorBackend`.

Addresses SonarCloud rule `python:S1192` (1 violation).

SonarCloud dashboard: https://sonarcloud.io/project/issues?id=ansible_ansible-dev-tools&rules=python:S1192

## Type of Change

- [x] Enhancement

## Risk Analysis

- [x] **Low** — Narrowly scoped (extracting a repeated expression into a property has no behavioral change).

## Testing

Python syntax check and ruff linter pass. Full `tox -e lint` requires native compilation dependencies not available in the sandbox environment.