### PR TITLE
feat(ci): add workflow_dispatch for date-tagged from-main ADT image

### DIFF
--- a/.github/workflows/devel-image.yml
+++ b/.github/workflows/devel-image.yml
@@ -23,6 +23,8 @@ permissions:
 jobs:
   build:
     name: build-${{ matrix.arch }}
+    # Only build/push tmp images from main; non-main dispatch must not write to GHCR.
+    if: github.ref == 'refs/heads/main'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/devel-image.yml
+++ b/.github/workflows/devel-image.yml
@@ -1,4 +1,5 @@
-# Build community-ansible-dev-tools with ADT ecosystem packages from git main.
+# Build community-ansible-dev-tools with ADT ecosystem packages from each
+# dependency repo's default-branch tip (see final/from-main-requirements.txt).
 # Publishes :YYYYMMDD (UTC) and floating :devel. Does not retag :main or :latest.
 #
 # To enable nightly from-main builds later, uncomment the schedule block below.

--- a/.github/workflows/devel-image.yml
+++ b/.github/workflows/devel-image.yml
@@ -1,0 +1,73 @@
+# Build community-ansible-dev-tools with ADT ecosystem packages from git main.
+# Publishes :YYYYMMDD (UTC) and floating :devel. Does not retag :main or :latest.
+#
+# To enable nightly from-main builds later, uncomment the schedule block below.
+name: devel-image
+
+on:
+  workflow_dispatch:
+  # schedule:
+  #   - cron: "0 0 * * *"
+
+concurrency:
+  # Do not cancel in-flight runs: publish tags :YYYYMMDD then :devel sequentially;
+  # cancel mid-loop can leave those tags pointing at different builds.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    name: build-${{ matrix.arch }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: devtools-multiarch-builder
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Switch to using Python 3.13 by default
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install tox
+        run: python3 -m pip install --user "tox>=4.46.0" "tox-uv>=1.32.0"
+
+      - name: Run test setup
+        run: ./tools/test-setup.sh
+
+      - name: Build from-main image
+        env:
+          ADT_IMAGE_FROM_MAIN: "1"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 -m tox -e ee-devel
+
+  publish:
+    name: publish-devel
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Publish :YYYYMMDD and :devel manifests
+        env:
+          ADT_IMAGE_FROM_MAIN: "1"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DATE_TAG="$(date -u +%Y%m%d)"
+          echo "Publishing ghcr.io/ansible/community-ansible-dev-tools:${DATE_TAG} and :devel"
+          ./tools/ee.sh --publish "${DATE_TAG}" "devel"

--- a/docs/container.md
+++ b/docs/container.md
@@ -12,6 +12,17 @@ The current version in use can be found in the [`execution-environment.yml`](htt
 podman pull ghcr.io/ansible/community-ansible-dev-tools:latest
 ```
 
+## Image tags
+
+| Tag | Contents |
+| --- | --- |
+| `:latest` | Last **release** of `ansible-dev-tools` with ADT dependencies from PyPI release versions. |
+| `:main` | Built from this repository's `main` branch; `ansible-dev-tools` is the current tip, but other ADT packages are still the latest **released** versions from PyPI. |
+| `:devel` | Built on demand (GitHub Actions `devel-image` workflow) with ADT ecosystem packages installed from each project's default branch tip (same set as `tox -e devel` / [`final/from-main-requirements.txt`](https://github.com/ansible/ansible-dev-tools/blob/main/final/from-main-requirements.txt)). Floating tag; moves on each successful dispatch. |
+| `:YYYYMMDD` | Same contents as that dispatch's `:devel` build, tagged with the UTC date at publish time. Prefer over `:devel` when you want a day-scoped reference; a second successful dispatch on the same UTC day overwrites the date tag (last build wins). For a content-addressed pin, use the image digest. |
+
+The `devel-image` workflow is manual (`workflow_dispatch`) and can later gain a nightly `schedule` without changing the image contents or tag scheme. Locally you can build the same image with `tox -e ee-devel` (sets `ADT_IMAGE_FROM_MAIN=1`). Container tests run before publish, so a broken tip can block a `:devel` image until the tip is green again.
+
 ## Usage
 
 ### Using this as a VS code Dev Container

--- a/final/Containerfile
+++ b/final/Containerfile
@@ -10,9 +10,15 @@ LABEL org.opencontainers.image.description="An execution environment targeted fo
 
 USER root
 
+# Set to 1 to overlay ADT ecosystem packages from git tip after the wheel install
+# (used for :devel / date-tagged images). Default keeps PyPI release deps.
+# ARG (not ENV) so the flag is available to RUN setup.sh but not baked into the image.
+ARG ADT_IMAGE_FROM_MAIN=0
+
 ENV _CONTAINERS_USERNS_CONFIGURED=""
 ENV ANSIBLE_DEV_TOOLS_CONTAINER=1
 ENV PIP_ROOT_USER_ACTION=ignore
+# ARG above is in scope for this RUN (not persisted as ENV in the image).
 RUN --mount=type=bind,target=/final --mount=type=cache,dst=/var/cache/dnf --mount=type=cache,dst=/root/.cache/pip /final/setup.sh
 
 # Note VOLUME options must always happen after setup.sh due to some chown inside that affects the mount

--- a/final/Containerfile
+++ b/final/Containerfile
@@ -18,8 +18,10 @@ ARG ADT_IMAGE_FROM_MAIN=0
 ENV _CONTAINERS_USERNS_CONFIGURED=""
 ENV ANSIBLE_DEV_TOOLS_CONTAINER=1
 ENV PIP_ROOT_USER_ACTION=ignore
-# ARG above is in scope for this RUN (not persisted as ENV in the image).
-RUN --mount=type=bind,target=/final --mount=type=cache,dst=/var/cache/dnf --mount=type=cache,dst=/root/.cache/pip /final/setup.sh
+# Pass ARG explicitly into the RUN env (same pattern as devspaces/Containerfile);
+# do not use ENV so the flag is not baked into the image config.
+RUN --mount=type=bind,target=/final --mount=type=cache,dst=/var/cache/dnf --mount=type=cache,dst=/root/.cache/pip \
+    ADT_IMAGE_FROM_MAIN="${ADT_IMAGE_FROM_MAIN}" /final/setup.sh
 
 # Note VOLUME options must always happen after setup.sh due to some chown inside that affects the mount
 # RUN commands can not modify existing volumes

--- a/final/from-main-requirements.txt
+++ b/final/from-main-requirements.txt
@@ -1,0 +1,12 @@
+# ADT ecosystem packages from git tip (default branch of each repo).
+# Shared by tox.env.devel and final/setup.sh (ADT_IMAGE_FROM_MAIN=1).
+# Note: ansible/ansible's default branch is devel, not main.
+ansible-compat @ git+https://github.com/ansible/ansible-compat.git
+ansible-core @ git+https://github.com/ansible/ansible.git
+ansible-creator @ git+https://github.com/ansible/ansible-creator.git
+ansible-dev-environment @ git+https://github.com/ansible/ansible-dev-environment.git
+ansible-lint @ git+https://github.com/ansible/ansible-lint.git
+ansible-navigator @ git+https://github.com/ansible/ansible-navigator.git
+molecule @ git+https://github.com/ansible/molecule.git
+pytest-ansible @ git+https://github.com/ansible/pytest-ansible.git
+tox-ansible @ git+https://github.com/ansible/tox-ansible.git

--- a/final/setup.sh
+++ b/final/setup.sh
@@ -103,6 +103,14 @@ done
 # this must run as user root
 find "$DIR/dist/" -iname '*.whl' -maxdepth 1 -exec python3 -m pip install --no-cache-dir '{}[server]' \;
 
+# Overlay ADT ecosystem packages from git tip (final/from-main-requirements.txt,
+# shared with tox.env.devel) so :devel / date-tagged images pick up unreleased
+# tips. Leave default images on PyPI release versions from the wheel install.
+if [ "${ADT_IMAGE_FROM_MAIN:-0}" = "1" ]; then
+    python3 -m pip install --no-cache-dir --upgrade --force-reinstall \
+        -r "$DIR/from-main-requirements.txt"
+fi
+
 mkdir -p ~/.ansible/roles /usr/share/ansible/roles /etc/ansible/roles
 git config --system --add safe.directory /
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -568,7 +568,7 @@ commands = [["python", "-m", "build", "--version"], ["./tools/ee.sh"]]
 commands_post = [["./tools/cleanup.sh"]]
 commands_pre = []
 dependency_groups = ["ee", "dev"]
-description = "Build the ee container image with ADT packages from git main"
+description = "Build the ee container image with ADT packages from default-branch tips"
 editable = true
 extras = ["server"]
 set_env = { ADT_IMAGE_FROM_MAIN = "1" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -513,16 +513,8 @@ skip_install = true
 base_python = "python3.13"
 dependency_groups = ["dev"]
 deps = [
-  "ansible-compat@ git+https://github.com/ansible/ansible-compat.git",
-  "ansible-core@ git+https://github.com/ansible/ansible.git",
-  "ansible-creator@ git+https://github.com/ansible/ansible-creator.git",
-  "ansible-dev-environment@ git+https://github.com/ansible/ansible-dev-environment.git",
-  "ansible-lint@ git+https://github.com/ansible/ansible-lint.git",
-  "ansible-navigator@ git+https://github.com/ansible/ansible-navigator.git",
-  "molecule@ git+https://github.com/ansible/molecule.git",
-  "pytest-ansible@ git+https://github.com/ansible/pytest-ansible.git",
-  "pytest<9.1",  # libtmux applies marks to fixtures, blocked by pytest 9.1+ (https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function)
-  "tox-ansible@ git+https://github.com/ansible/tox-ansible.git"
+  "-r{tox_root}/final/from-main-requirements.txt",
+  "pytest<9.1"  # libtmux applies marks to fixtures, blocked by pytest 9.1+ (https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function)
 ]
 runner = "uv-venv-runner"
 uv_sync_flags = ["--upgrade", "--prerelease=allow"]
@@ -569,6 +561,17 @@ dependency_groups = ["ee", "dev"]
 description = "Build the ee container image"
 editable = true
 extras = ["server"]
+skip_install = false
+
+[tool.tox.env.ee-devel]
+commands = [["python", "-m", "build", "--version"], ["./tools/ee.sh"]]
+commands_post = [["./tools/cleanup.sh"]]
+commands_pre = []
+dependency_groups = ["ee", "dev"]
+description = "Build the ee container image with ADT packages from git main"
+editable = true
+extras = ["server"]
+set_env = { ADT_IMAGE_FROM_MAIN = "1" }
 skip_install = false
 
 [tool.tox.env.lint]

--- a/tools/ee.sh
+++ b/tools/ee.sh
@@ -4,9 +4,10 @@ set -exuo pipefail
 
 
 ADT_CONTAINER_ENGINE=${ADT_CONTAINER_ENGINE:-docker}
-# When set to 1, final image overlays ADT ecosystem packages from git main
-# (see final/setup.sh) and uses a distinct tmp tag suffix to avoid colliding
-# with the default :main build for the same commit SHA.
+# When set to 1, final image overlays ADT ecosystem packages from each repo's
+# default-branch tip (see final/setup.sh / from-main-requirements.txt) and uses
+# a distinct tmp tag suffix to avoid colliding with the default :main build for
+# the same commit SHA.
 ADT_IMAGE_FROM_MAIN="${ADT_IMAGE_FROM_MAIN:-0}"
 TMP_TAG_SUFFIX=""
 if [ "${ADT_IMAGE_FROM_MAIN}" = "1" ]; then

--- a/tools/ee.sh
+++ b/tools/ee.sh
@@ -5,9 +5,9 @@ set -exuo pipefail
 
 ADT_CONTAINER_ENGINE=${ADT_CONTAINER_ENGINE:-docker}
 # When set to 1, final image overlays ADT ecosystem packages from each repo's
-# default-branch tip (see final/setup.sh / from-main-requirements.txt) and uses
-# a distinct tmp tag suffix to avoid colliding with the default :main build for
-# the same commit SHA.
+# default-branch tip (see final/setup.sh / final/from-main-requirements.txt) and
+# uses a distinct tmp tag suffix to avoid colliding with the default :main build
+# for the same commit SHA.
 ADT_IMAGE_FROM_MAIN="${ADT_IMAGE_FROM_MAIN:-0}"
 TMP_TAG_SUFFIX=""
 if [ "${ADT_IMAGE_FROM_MAIN}" = "1" ]; then

--- a/tools/ee.sh
+++ b/tools/ee.sh
@@ -4,6 +4,14 @@ set -exuo pipefail
 
 
 ADT_CONTAINER_ENGINE=${ADT_CONTAINER_ENGINE:-docker}
+# When set to 1, final image overlays ADT ecosystem packages from git main
+# (see final/setup.sh) and uses a distinct tmp tag suffix to avoid colliding
+# with the default :main build for the same commit SHA.
+ADT_IMAGE_FROM_MAIN="${ADT_IMAGE_FROM_MAIN:-0}"
+TMP_TAG_SUFFIX=""
+if [ "${ADT_IMAGE_FROM_MAIN}" = "1" ]; then
+    TMP_TAG_SUFFIX="-from-main"
+fi
 
 # Identify the architecture in format used by the container engines because
 # `arch` command returns either arm64 or aarch64 depending on the system
@@ -46,18 +54,19 @@ if [ "--publish" == "${1:-}" ]; then
 
     FINAL_REPO="ghcr.io/ansible/community-ansible-dev-tools"
     TMP_REPO="ghcr.io/ansible/community-ansible-dev-tools-tmp"
+    SHA_TAG="${GITHUB_SHA:-}${TMP_TAG_SUFFIX}"
 
-    ${ADT_CONTAINER_ENGINE} pull -q "${TMP_REPO}:${GITHUB_SHA:-}-arm64"
-    ${ADT_CONTAINER_ENGINE} pull -q "${TMP_REPO}:${GITHUB_SHA:-}-amd64"
+    ${ADT_CONTAINER_ENGINE} pull -q "${TMP_REPO}:${SHA_TAG}-arm64"
+    ${ADT_CONTAINER_ENGINE} pull -q "${TMP_REPO}:${SHA_TAG}-amd64"
 
     # Re-tag and push arch-specific images to the final repository to avoid
     # cross-repository blob mounting issues when creating the manifest.
     # GHCR cannot mount blobs across different repositories, so we must push
     # the images to the target repository before creating the manifest.
     for IMG_ARCH in amd64 arm64; do
-        ${ADT_CONTAINER_ENGINE} tag "${TMP_REPO}:${GITHUB_SHA:-}-${IMG_ARCH}" "${FINAL_REPO}:${GITHUB_SHA:-}-${IMG_ARCH}"
+        ${ADT_CONTAINER_ENGINE} tag "${TMP_REPO}:${SHA_TAG}-${IMG_ARCH}" "${FINAL_REPO}:${SHA_TAG}-${IMG_ARCH}"
         if [ "${CI:-}" == "true" ]; then
-            ${ADT_CONTAINER_ENGINE} push "${FINAL_REPO}:${GITHUB_SHA:-}-${IMG_ARCH}"
+            ${ADT_CONTAINER_ENGINE} push "${FINAL_REPO}:${SHA_TAG}-${IMG_ARCH}"
         fi
     done
 
@@ -67,8 +76,8 @@ if [ "--publish" == "${1:-}" ]; then
     fi
 
     for TAG in "${TAGS[@]}"; do
-        ${ADT_CONTAINER_ENGINE} manifest create "$TAG" --amend "${FINAL_REPO}:${GITHUB_SHA:-}-amd64" --amend "${FINAL_REPO}:${GITHUB_SHA:-}-arm64"
-        ${ADT_CONTAINER_ENGINE} manifest annotate --arch arm64 "$TAG" "${FINAL_REPO}:${GITHUB_SHA:-}-arm64"
+        ${ADT_CONTAINER_ENGINE} manifest create "$TAG" --amend "${FINAL_REPO}:${SHA_TAG}-amd64" --amend "${FINAL_REPO}:${SHA_TAG}-arm64"
+        ${ADT_CONTAINER_ENGINE} manifest annotate --arch arm64 "$TAG" "${FINAL_REPO}:${SHA_TAG}-arm64"
 
         if [ "${CI:-}" == "true" ]; then
             ${ADT_CONTAINER_ENGINE} manifest push "$TAG"
@@ -85,7 +94,9 @@ python -m build --outdir "$REPO_DIR/final/dist/" --wheel "$REPO_DIR"
 ansible-builder create -f execution-environment.yml --output-filename Containerfile -v3
 $BUILD_CMD -f context/Containerfile context/ --tag "${TAG_BASE}"
 ln -f tools/setup-image.sh final/
-$BUILD_CMD -f final/Containerfile final/ --tag "${IMAGE_NAME}"
+$BUILD_CMD \
+    --build-arg "ADT_IMAGE_FROM_MAIN=${ADT_IMAGE_FROM_MAIN}" \
+    -f final/Containerfile final/ --tag "${IMAGE_NAME}"
 
 # We save local image in order to import it inside the container later for c-in-c testing
 # Do not try to gzip the image because there is no notable change in size and
@@ -99,7 +110,7 @@ ansible-builder build --container-runtime="${ADT_CONTAINER_ENGINE}"
 popd
 
 if [[ -n "${GITHUB_SHA:-}" && "${GITHUB_EVENT_NAME:-}" != "pull_request" ]]; then
-    FQ_IMAGE_NAME="ghcr.io/ansible/community-ansible-dev-tools-tmp:${GITHUB_SHA}-$ARCH"
+    FQ_IMAGE_NAME="ghcr.io/ansible/community-ansible-dev-tools-tmp:${GITHUB_SHA}${TMP_TAG_SUFFIX}-$ARCH"
     $ADT_CONTAINER_ENGINE tag $IMAGE_NAME "${FQ_IMAGE_NAME}"
     # https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry
     set +x  # Disable echo for lines with GITHUB_TOKEN


### PR DESCRIPTION
## Summary
- Add a manual `devel-image` workflow that builds `community-ansible-dev-tools` with ADT ecosystem packages from each project's default-branch tip (same set as `tox -e devel`).
- Publish `:YYYYMMDD` (UTC) and floating `:devel`; do not retag `:main` or `:latest`.
- Share the from-main package list in `final/from-main-requirements.txt` for both the image overlay and `tox -e devel`.

## Changes
- `ADT_IMAGE_FROM_MAIN=1` overlays git tips after the ADT wheel install in `final/setup.sh` (Containerfile `ARG` passed explicitly into the `RUN` env, not baked as image `ENV`).
- `tools/ee.sh` passes the build-arg and uses a `-from-main` tmp tag suffix to avoid colliding with the normal `:main` build for the same SHA.
- New `tox -e ee-devel` for local from-main image builds.
- `.github/workflows/devel-image.yml`: `workflow_dispatch` (cron stubbed for later); build and publish both gated to `main` so non-main dispatch cannot write to GHCR; `cancel-in-progress: false` to avoid desyncing `:YYYYMMDD` vs `:devel`.
- Docs: image tag table in `docs/container.md`.

## Quality of life
- Single shared requirements file for from-main deps (`tox -e devel` + image overlay).
- Nightly schedule can be enabled later with one uncommented cron line.

## Test plan
- [x] `tox -e lint` passes
- [x] `tox -e py` passes
- [x] Docs updated (`docs/container.md`)
- [ ] After merge: Actions → `devel-image` → Run workflow on `main`
- [ ] Pull `ghcr.io/ansible/community-ansible-dev-tools:devel` and confirm `adt --version` shows tip versions (e.g. creator not stuck on last PyPI release only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added development container images built from the latest default-branch packages.
  - Added multi-architecture development images for AMD64 and ARM64.
  - Added date-based and `devel` image tags for easier access to recent builds.
  - Development images are tested before publication.

- **Documentation**
  - Added guidance for available container tags, local development-image builds, and usage recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->