### PR TITLE
ci: enable nightly schedule for devel-image

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -1,5 +1,6 @@
 Ansibuddy
 BUILDAH
+Buildah
 Containerfile
 DEVWORKSPACE
 Devfile

--- a/.github/workflows/devel-image.yml
+++ b/.github/workflows/devel-image.yml
@@ -2,13 +2,15 @@
 # dependency repo's default-branch tip (see final/from-main-requirements.txt).
 # Publishes :YYYYMMDD (UTC) and floating :devel. Does not retag :main or :latest.
 #
-# To enable nightly from-main builds later, uncomment the schedule block below.
+# Nightly schedule enabled after a successful manual run:
+# https://github.com/ansible/ansible-dev-tools/actions/runs/29510692708
+# (:devel / :20260716 validated with tip .dev* ADT packages).
 name: devel-image
 
 on:
   workflow_dispatch:
-  # schedule:
-  #   - cron: "0 0 * * *"
+  schedule:
+    - cron: "0 0 * * *"
 
 concurrency:
   # Do not cancel in-flight runs: publish tags :YYYYMMDD then :devel sequentially;

--- a/docs/container.md
+++ b/docs/container.md
@@ -18,10 +18,10 @@ podman pull ghcr.io/ansible/community-ansible-dev-tools:latest
 | --- | --- |
 | `:latest` | Last **release** of `ansible-dev-tools` with ADT dependencies from PyPI release versions. |
 | `:main` | Built from this repository's `main` branch; `ansible-dev-tools` is the current tip, but other ADT packages are still the latest **released** versions from PyPI. |
-| `:devel` | Built on demand (GitHub Actions `devel-image` workflow) with ADT ecosystem packages installed from each project's default branch tip (same set as `tox -e devel` / [`final/from-main-requirements.txt`](https://github.com/ansible/ansible-dev-tools/blob/main/final/from-main-requirements.txt)). Floating tag; moves on each successful dispatch. |
-| `:YYYYMMDD` | Same contents as that dispatch's `:devel` build, tagged with the UTC date at publish time. Prefer over `:devel` when you want a day-scoped reference; a second successful dispatch on the same UTC day overwrites the date tag (last build wins). For a content-addressed pin, use the image digest. |
+| `:devel` | Built by the GitHub Actions `devel-image` workflow (nightly UTC midnight and `workflow_dispatch`) with ADT ecosystem packages installed from each project's default branch tip (same set as `tox -e devel` / [`final/from-main-requirements.txt`](https://github.com/ansible/ansible-dev-tools/blob/main/final/from-main-requirements.txt)). Floating tag; moves on each successful run. |
+| `:YYYYMMDD` | Same contents as that run's `:devel` build, tagged with the UTC date at publish time. Prefer over `:devel` when you want a day-scoped reference; a second successful run on the same UTC day overwrites the date tag (last build wins). For a content-addressed pin, use the image digest. |
 
-The `devel-image` workflow is manual (`workflow_dispatch`) and can later gain a nightly `schedule` without changing the image contents or tag scheme. Locally you can build the same image with `tox -e ee-devel` (sets `ADT_IMAGE_FROM_MAIN=1`). Container tests run before publish, so a broken tip can block a `:devel` image until the tip is green again.
+The `devel-image` workflow runs on a nightly `schedule` (`0 0 * * *` UTC) and on demand via `workflow_dispatch`. Locally you can build the same image with `tox -e ee-devel` (sets `ADT_IMAGE_FROM_MAIN=1`). Container tests run before publish, so a broken tip can block a `:devel` image until the tip is green again.
 
 ## Usage
 

--- a/src/ansible_dev_tools/tests/integration/test_container.py
+++ b/src/ansible_dev_tools/tests/integration/test_container.py
@@ -341,8 +341,9 @@ def test_builder(
         tmp_path: The temporary directory.
     """
     ee_file = test_fixture_dir_container / "execution-environment.yml"
-    # Nested podman (vfs) layers from earlier c-in-c tests can fill the container
-    # filesystem on self-hosted builders (out of disk during builder steps).
-    exec_container("podman system prune -af --volumes || true")
+    # Nested podman (vfs) build cache from earlier c-in-c tests can fill the
+    # container filesystem on self-hosted builders. Prune build cache only so
+    # images loaded for other container tests are not removed.
+    exec_container("podman image prune -f --build-cache || true")
     result = exec_container(f"ANSIBLE_NOCOLOR=1 ansible-builder build -f {ee_file} -c {tmp_path}")
     assert "Complete!" in result.stdout

--- a/src/ansible_dev_tools/tests/integration/test_container.py
+++ b/src/ansible_dev_tools/tests/integration/test_container.py
@@ -341,5 +341,8 @@ def test_builder(
         tmp_path: The temporary directory.
     """
     ee_file = test_fixture_dir_container / "execution-environment.yml"
+    # Nested podman (vfs) layers from earlier c-in-c tests can fill the container
+    # filesystem on self-hosted builders (out of disk during builder steps).
+    exec_container("podman system prune -af --volumes || true")
     result = exec_container(f"ANSIBLE_NOCOLOR=1 ansible-builder build -f {ee_file} -c {tmp_path}")
     assert "Complete!" in result.stdout

--- a/tools/ee.sh
+++ b/tools/ee.sh
@@ -88,6 +88,16 @@ if [ "--publish" == "${1:-}" ]; then
 fi
 
 # Code for building the container (call script again with --publish to merge and push already build container)
+
+# Self-hosted builders keep docker/podman cache across jobs; leftover layers
+# have been causing out-of-disk errors in nested ansible-builder (test_builder).
+if [ "${CI:-}" = "true" ]; then
+    df -h || true
+    ${ADT_CONTAINER_ENGINE} system prune -af --volumes || true
+    ${ADT_CONTAINER_ENGINE} builder prune -af || true
+    df -h || true
+fi
+
 if [ -d "$REPO_DIR/final/dist/" ]; then
     find "$REPO_DIR/final/dist/" -type f -delete
 fi
@@ -103,6 +113,12 @@ $BUILD_CMD \
 # Do not try to gzip the image because there is no notable change in size and
 # it seems to add ~20% more in total test execution time.
 $ADT_CONTAINER_ENGINE save $IMAGE_NAME > image.tar
+
+# Drop intermediate base/build cache before nested EE builds; keep the test image.
+${ADT_CONTAINER_ENGINE} rmi "${TAG_BASE}" || true
+${ADT_CONTAINER_ENGINE} builder prune -af || true
+${ADT_CONTAINER_ENGINE} image prune -f || true
+df -h || true
 
 pytest -v src/ansible_dev_tools/tests --include-container --container-engine="${ADT_CONTAINER_ENGINE}" --image-name "${IMAGE_NAME}"
 # Test the build of example execution environment to avoid regressions

--- a/tools/ee.sh
+++ b/tools/ee.sh
@@ -89,12 +89,21 @@ fi
 
 # Code for building the container (call script again with --publish to merge and push already build container)
 
-# Self-hosted builders keep docker/podman cache across jobs; leftover layers
-# have been causing out-of-disk errors in nested ansible-builder (test_builder).
+# Free build cache only (not system prune) on CI. Self-hosted builders share a
+# daemon across jobs; aggressive prune can disrupt siblings, but leftover
+# BuildKit/Buildah cache has caused out-of-disk errors in nested ansible-builder.
+prune_build_cache() {
+    if [[ "${ADT_CONTAINER_ENGINE}" == *podman* ]]; then
+        # Podman has no docker-compatible `builder prune`.
+        ${ADT_CONTAINER_ENGINE} image prune -f --build-cache || true
+    else
+        ${ADT_CONTAINER_ENGINE} builder prune -af || true
+    fi
+}
+
 if [ "${CI:-}" = "true" ]; then
     df -h || true
-    ${ADT_CONTAINER_ENGINE} system prune -af --volumes || true
-    ${ADT_CONTAINER_ENGINE} builder prune -af || true
+    prune_build_cache
     df -h || true
 fi
 
@@ -114,11 +123,13 @@ $BUILD_CMD \
 # it seems to add ~20% more in total test execution time.
 $ADT_CONTAINER_ENGINE save $IMAGE_NAME > image.tar
 
-# Drop intermediate base/build cache before nested EE builds; keep the test image.
-${ADT_CONTAINER_ENGINE} rmi "${TAG_BASE}" || true
-${ADT_CONTAINER_ENGINE} builder prune -af || true
-${ADT_CONTAINER_ENGINE} image prune -f || true
-df -h || true
+# CI only: drop this job's intermediate base + build cache before nested EE builds.
+# Keep IMAGE_NAME for pytest; do not system-prune the shared host daemon.
+if [ "${CI:-}" = "true" ]; then
+    ${ADT_CONTAINER_ENGINE} rmi "${TAG_BASE}" || true
+    prune_build_cache
+    df -h || true
+fi
 
 pytest -v src/ansible_dev_tools/tests --include-container --container-engine="${ADT_CONTAINER_ENGINE}" --image-name "${IMAGE_NAME}"
 # Test the build of example execution environment to avoid regressions


### PR DESCRIPTION
## Summary
- Enable the nightly `schedule` (`0 0 * * *` UTC) on the `devel-image` workflow now that a manual run succeeded end-to-end.
- Update `docs/container.md` so tag docs match (nightly + `workflow_dispatch`).
- Unblock flaky `tox / ee-amd64` on self-hosted builders (out of disk during nested `ansible-builder`) without broadly pruning the shared host daemon.

## Evidence (manual run)
- Run: https://github.com/ansible/ansible-dev-tools/actions/runs/29510692708 (success)
- Tags: `ghcr.io/ansible/community-ansible-dev-tools:devel` and `:20260716` (same image)
- Sample tip versions from `:devel` (vs `:main` still on PyPI releases):
  - ansible-creator `26.6.2.dev7` (main: `26.6.1`)
  - ansible-core `2.22.0.dev0` (main: `2.21.2`)
  - ansible-lint `26.6.1.dev9` (main: `26.6.0`)

## Changes
- Uncomment `schedule` in `.github/workflows/devel-image.yml` and note the validating run in the header comment.
- Docs: nightly + on-demand wording for `:devel` / `:YYYYMMDD`.
- `tools/ee.sh` (CI only): engine-specific build-cache prune + `rmi` of this job's intermediate `TAG_BASE` (Docker `builder prune`; Podman `image prune --build-cache`). No `system prune -af --volumes`.
- `test_builder`: nested `podman image prune -f --build-cache` before the EE build so other loaded test images stay intact.

## Quality of life
- Header comment links the successful Actions run for future archaeology.

## Test plan
- [x] `tox -e lint` passes
- [x] `tox -e py` passes
- [x] Docs updated
- [x] CI: `tox / ee-amd64` green after prune fix (run 29521197107)
- [ ] After merge: confirm next UTC midnight run appears under Actions → `devel-image`

Related: #788