### PR TITLE
fix(deps): bump django>=5.2.17 for CVE-2026-15307

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ container = ["ansible-pylibssh==1.4.0; platform_system == 'Linux'"]
 # https://github.com/ansible/pylibssh/issues/699
 # 'container' not included in all because pylibssh still causes build issues
 full = ["ansible-dev-tools[server,test]"]
-server = ["django>4.1,<6.0", "gunicorn>=23.0.0", "openapi-core>=0.19.1"]
+server = ["django>=5.2.17,<6.0", "gunicorn>=23.0.0", "openapi-core>=0.19.1"]
 test = [
   "ansible-dev-tools[server]",
   "libtmux>=0.46.0",

--- a/uv.lock
+++ b/uv.lock
@@ -216,7 +216,7 @@ requires-dist = [
     { name = "ansible-navigator", specifier = ">=26.1.3" },
     { name = "ansible-pylibssh", marker = "sys_platform == 'linux' and extra == 'container'", specifier = "==1.4.0" },
     { name = "ansible-sign", specifier = ">=0.1.5" },
-    { name = "django", marker = "extra == 'server'", specifier = ">4.1,<6.0" },
+    { name = "django", marker = "extra == 'server'", specifier = ">=5.2.17,<6.0" },
     { name = "gunicorn", marker = "extra == 'server'", specifier = ">=23.0.0" },
     { name = "libtmux", marker = "extra == 'test'", specifier = ">=0.46.0" },
     { name = "molecule", specifier = ">=26.3.0" },
@@ -938,15 +938,15 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "5.2.16"
+version = "5.2.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/26/889449d521ae508b26de715954faecd8bcf3f740affb81b2d146a83b42a5/django-5.2.16.tar.gz", hash = "sha256:59ea02020c3136fce14bef0bbece21a10a4febef5eed1c51c22ae468efa22200", size = 10890894, upload-time = "2026-07-07T13:52:17.005Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/d8/43e9d000519adceb189620b6869ff88031e046df91c2e9da72f8f6918399/django-5.2.17.tar.gz", hash = "sha256:9d4d93be539a18ab80d058eb515900e10951e04c537c5a6b394fc49528d3251f", size = 10889740, upload-time = "2026-08-04T15:04:03.173Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/13/1e5e3e4c15dcecb04281b3cb2a46a4670e1cef131068e202f6040df19224/django-5.2.16-py3-none-any.whl", hash = "sha256:04f354bf9d807a86ad1a8392fe3808d362358a8eafc322848e0e43e59b24371d", size = 8311943, upload-time = "2026-07-07T13:52:11.223Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f8/ce120525ca78f12b07daf65786679c5d0b54a75285a8958d3ae55e39da35/django-5.2.17-py3-none-any.whl", hash = "sha256:f04fb3b36ee119e1af4fa1d397d5fd6cf12700f49321e84d4f4c642c5b1973db", size = 8315563, upload-time = "2026-08-04T15:03:59.1Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bump Django lower bound from `>4.1` to `>=5.2.17` to address CVE-2026-15307 (GeoDjango GDALRaster RCE)
- Regenerate `uv.lock` to pin Django 5.2.17

## Context
- CVE-2026-15307 affects Django's GeoDjango spatial lookups (`django.contrib.gis.gdal.GDALRaster`)
- ansible-dev-tools does not use GeoDjango (zero references to `contrib.gis`, `GeometryField`, `RasterField`, or `GDALRaster`)
- Exploitability is very low for this project, but the version bump is required per PSIRT remediation process

## Test plan
- [x] `uv lock --upgrade-package django` resolves cleanly (5.2.16 -> 5.2.17)
- [ ] CI passes

Fixes: AAP-85786, AAP-85790, AAP-85793

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the server dependency to support Django 5.2.17 and newer, while remaining below version 6.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->