### PR TITLE
fix(deps): remove self-referential dependency from dev group

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -108,19 +108,6 @@ plugins:
   # https://github.com/squidfunk/mkdocs-material/issues/6983
   # - material/social
   - material/tags
-  - mkdocstrings:
-      handlers:
-        python:
-          paths: [src]
-          options:
-            # Sphinx is for historical reasons, but we could consider switching if needed
-            # https://mkdocstrings.github.io/griffe/docstrings/
-            docstring_style: sphinx
-            merge_init_into_class: yes
-            show_submodules: yes
-          inventories:
-            - url: https://docs.ansible.com/projects/ansible/latest/objects.inv
-              domains: [py, std]
 
 markdown_extensions:
   - attr_list

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,6 @@ test = [
 
 [dependency-groups]
 dev = [
-  "ansible-dev-tools[full]",  # see https://github.com/astral-sh/uv/issues/8607#issuecomment-2540156984
   "black>=25.1.0",
   "coverage[toml]>=7.10.5",
   "django-stubs>=5.2.2",

--- a/uv.lock
+++ b/uv.lock
@@ -165,7 +165,6 @@ test = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "ansible-dev-tools", extra = ["full"] },
     { name = "black" },
     { name = "coverage", extra = ["toml"] },
     { name = "django-stubs" },
@@ -231,7 +230,6 @@ provides-extras = ["container", "full", "server", "test"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "ansible-dev-tools", extras = ["full"], editable = "." },
     { name = "black", specifier = ">=25.1.0" },
     { name = "coverage", extras = ["toml"], specifier = ">=7.10.5" },
     { name = "django-stubs", specifier = ">=5.2.2" },


### PR DESCRIPTION
The `dev` dependency group in `pyproject.toml` lists `ansible-dev-tools[full]` as a dependency, but the project itself is `ansible-dev-tools`. This self-reference causes Dependabot to fail when resolving security updates because it tries to resolve the dependency graph without installing the project itself.

The self-reference is also redundant since tox already installs the project as editable, so all extras are available during development and testing anyway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the optional full Ansible development tools bundle from the development setup.
  * Simplified the documentation build configuration by removing automated Python API reference generation and the associated Ansible documentation inventory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->